### PR TITLE
Add 'install' as a target to make.

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -33,10 +33,11 @@ ifneq "$(TARGET)" "native"
         ARCH:=x86
         HOSTARCH:=x86_64
     endif
-    BUILD:=$(BUILDS)/cross-$(TARGET)
+    TARGET_BUILD_DIR:=cross-$(TARGET)
 else
-    BUILD:=$(BUILDS)/native-$(shell uname -s|tr '[:upper:]' '[:lower:]').$(shell uname -m)
+    TARGET_BUILD_DIR:=native-$(shell uname -s|tr '[:upper:]' '[:lower:]').$(shell uname -m)
 endif
+BUILD:=$(BUILDS)/$(TARGET_BUILD_DIR)
 
 LOGFILE=$(BUILD)/build.log
 ERRFILE=$(BUILD)/build.err

--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -40,3 +40,13 @@ $(BUILD)/bin/mettle.bin:
 	$(ELF2BIN) $(BUILD)/bin/mettle $(BUILD)/bin/mettle.bin
 
 mettle: $(BUILD)/mettle.built $(METTLE_DEPS)
+
+DATADIR:=../metasploit-framework/data
+METTLEDIR:=$(DATADIR)/mettle
+
+install: mettle
+	mkdir -p $(METTLEDIR)/$(TARGET_BUILD_DIR)
+	cp -ar build/$(TARGET_BUILD_DIR)/bin $(METTLEDIR)/$(TARGET_BUILD_DIR)
+
+uninstall:
+	rm -rf $(METTLEDIR)/$(TARGET_BUILD_DIR)


### PR DESCRIPTION
Now you can run 'make install TARGET=<your target>' at the toplevel of mettle to have it install your built mettle binaries into your metasploit-framework/data directory for local testing.  Woo!

# Verification

[ ] - ensure your metasploit-framework/data/mettle directory is either empty or does not exist (e.g. `rm -rf metasploit-framework/data/mettle`)
[ ] - clone and build mettle (e.g. `make TARGET=x86_64-linux-musl`)
[ ] - use the new 'install' target to install the mettle binaries you created (e.g. `make install TARGET=x86_64-linux-musl`)
[ ] - **verify** you see mettle.bin in the appropriate msf data directory (e.g. `find metasploit-framework/data/mettle/`, look for files in the associated TARGET directory)
[ ] - remove the files you just installed with `make uninstall` (e.g. `make uninstall TARGET=x86_64-linux-musl`)
[ ] -**verify** the associated metasploit-framework/data/mettle/ TARGET directory no longer exists