### PR TITLE
add initial machine_id code

### DIFF
--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -16,8 +16,6 @@
 #include "network_client.h"
 #include "tlv.h"
 
-#define MAX_PATH 256
-
 struct mettle {
 	struct channelmgr *cm;
 	struct network_client *nc;
@@ -197,38 +195,6 @@ struct mettle *mettle(void)
 err:
 	mettle_free(m);
 	return NULL;
-}
-
-const char * mettle_get_machine_id(void)
-{
-  struct utsname utsbuf;
-  struct dirent *data;
-  static char machine_id[MAX_PATH] = "";
-
-  if (uname(&utsbuf) == 0) {
-    strncat(machine_id, utsbuf.nodename, sizeof(machine_id) - strlen(utsbuf.nodename) - 1);
-  }
-
-  DIR *ctx = opendir("/dev/disk/by-uuid");
-
-  if (ctx) {
-    while ((data = readdir(ctx)) != NULL) {
-      if (!strcmp(data->d_name, ".") || !strcmp(data->d_name, "..")) {
-        /* skip */
-      }
-      else {
-        const char *partition_uuid = data->d_name;
-        strncat(machine_id, ":", sizeof(char));
-        strncat(machine_id, partition_uuid, sizeof(machine_id) - strlen(partition_uuid) - 1);
-
-        /* the first one encountered will do */
-        break;
-      }
-    }
-  }
-
-  closedir(ctx);
-  return machine_id;
 }
 
 int mettle_start(struct mettle *m)

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -16,6 +16,8 @@
 #include "network_client.h"
 #include "tlv.h"
 
+#define MAX_PATH 256
+
 struct mettle {
 	struct channelmgr *cm;
 	struct network_client *nc;
@@ -195,6 +197,38 @@ struct mettle *mettle(void)
 err:
 	mettle_free(m);
 	return NULL;
+}
+
+const char * mettle_get_machine_id(void)
+{
+  struct utsname utsbuf;
+  struct dirent *data;
+  static char machine_id[MAX_PATH] = "";
+
+  if (uname(&utsbuf) == 0) {
+    strncat(machine_id, utsbuf.nodename, sizeof(machine_id) - strlen(utsbuf.nodename) - 1);
+  }
+
+  DIR *ctx = opendir("/dev/disk/by-uuid");
+
+  if (ctx) {
+    while ((data = readdir(ctx)) != NULL) {
+      if (!strcmp(data->d_name, ".") || !strcmp(data->d_name, "..")) {
+        /* skip */
+      }
+      else {
+        const char *partition_uuid = data->d_name;
+        strncat(machine_id, ":", sizeof(char));
+        strncat(machine_id, partition_uuid, sizeof(machine_id) - strlen(partition_uuid) - 1);
+
+        /* the first one encountered will do */
+        break;
+      }
+    }
+  }
+
+  closedir(ctx);
+  return machine_id;
 }
 
 int mettle_start(struct mettle *m)

--- a/mettle/src/mettle.h
+++ b/mettle/src/mettle.h
@@ -11,8 +11,6 @@
 
 #include <ev.h>
 #include <sigar.h>
-#include <dirent.h>
-#include <sys/utsname.h>
 
 struct mettle * mettle(void);
 

--- a/mettle/src/mettle.h
+++ b/mettle/src/mettle.h
@@ -11,6 +11,8 @@
 
 #include <ev.h>
 #include <sigar.h>
+#include <dirent.h>
+#include <sys/utsname.h>
 
 struct mettle * mettle(void);
 
@@ -31,5 +33,7 @@ int mettle_add_server_uri(struct mettle *m, const char *uri);
 int mettle_add_tcp_sock(struct mettle *m, int fd);
 
 struct channelmgr * mettle_get_channelmgr(struct mettle *m);
+
+const char * mettle_get_machine_id(void);
 
 #endif

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -9,6 +9,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <dirent.h>
+#include <sys/utsname.h>
 
 #include <dnet.h>
 

--- a/mettle/src/tlv_coreapi.c
+++ b/mettle/src/tlv_coreapi.c
@@ -294,7 +294,7 @@ void tlv_register_coreapi(struct mettle *m)
 	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
 
 	tlv_dispatcher_add_handler(td, "core_enumextcmd", enumextcmd, m);
-	tlv_dispatcher_add_handler(td, "core_machine_id", mettle_machine_id, m);
+	tlv_dispatcher_add_handler(td, "core_machine_id", mettle_get_machine_id, m);
 	tlv_dispatcher_add_handler(td, "core_shutdown", core_shutdown, m);
 	tlv_dispatcher_add_handler(td, "core_channel_open", core_channel_open, m);
 	tlv_dispatcher_add_handler(td, "core_channel_eof", core_channel_eof, m);

--- a/mettle/src/tlv_coreapi.c
+++ b/mettle/src/tlv_coreapi.c
@@ -263,6 +263,10 @@ const char * mettle_get_machine_id(void)
   struct dirent *data;
   static char machine_id[UUID_MAX] = "";
 
+  if(strlen(machine_id)) {
+    return machine_id;
+  }
+
   if (uname(&utsbuf) == 0) {
     strncat(machine_id, utsbuf.nodename, sizeof(machine_id) - strlen(utsbuf.nodename) - 1);
   }
@@ -271,13 +275,17 @@ const char * mettle_get_machine_id(void)
 
   if (ctx) {
     while ((data = readdir(ctx)) != NULL) {
-      if (!strcmp(data->d_name, ".") || !strcmp(data->d_name, "..")) {
-        /* skip */
-      }
-      else {
-        const char *partition_uuid = data->d_name;
+
+      /*
+       * we don't care about optical drives and the like,
+       * and the d_name field is the only one we can count
+       * on in POSIX systems
+       */
+
+      if (strlen(data->d_name) == 36) {
+        const char *drive_serial = data->d_name;
         strncat(machine_id, ":", sizeof(char));
-        strncat(machine_id, partition_uuid, sizeof(machine_id) - strlen(partition_uuid) - 1);
+        strncat(machine_id, drive_serial, sizeof(machine_id) - strlen(drive_serial) - 1);
 
         /* the first one encountered will do */
         break;


### PR DESCRIPTION
Refactor mettle_get_machine_id() to return a string derived from the hostname and first encountered partition UUID