### PR TITLE
partial mingw32 support - fix dependencies

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -16,7 +16,16 @@ ERRFILE=$(BUILD)/build.err
 DEPS=$(ROOT)/deps
 OUTPUTDIR=$(BUILD)/data
 
-CFLAGS:=$(CFLAGS) -Os -fPIE -I$(BUILD)/include
+CFLAGS:=$(CFLAGS) -Os -I$(BUILD)/include
+ifeq (,$(findstring mingw,$(TARGET)))
+    CFLAGS:=$(CFLAGS) -fPIE
+    ifneq (,$(findstring sparc,$(TARGET)))
+        CFLAGS:=$(CFLAGS) -fPIC
+    else
+        CFLAGS:=$(CFLAGS) -fpic
+    endif
+endif
+
 CPPFLAGS:=-I$(BUILD)/include
 CONFIGURE=configure --prefix=$(BUILD) --disable-shared ac_cv_path_PKGCONFIG=$(CWD)/pkg-config
 ifneq "$(TARGET)" "native"
@@ -24,12 +33,6 @@ ifneq "$(TARGET)" "native"
 endif
 ifneq "$(HOST)" ""
     CONFIGURE:=$(CONFIGURE) --host=$(HOST)
-endif
-
-ifneq (,$(findstring sparc,$(TARGET)))
-    CFLAGS:=$(CFLAGS) -fPIC
-else
-    CFLAGS:=$(CFLAGS) -fpic
 endif
 
 # if Debug is enabled, build with debug symbols, otherwise strip the symbol table

--- a/make/Makefile.libdnet
+++ b/make/Makefile.libdnet
@@ -6,12 +6,24 @@ $(BUILD)/libdnet/configure:
 		$(TAR) zxf $(ROOT)/deps/libdnet-1.12.tar.gz; \
 		mv libdnet-1.12 libdnet
 
-DNET_CONFIGURE_FLAGS=
+DNET_CONFIGURE_FLAGS:=""
 ifneq "$(TARGET)" "native"
-	DNET_CONFIGURE_FLAGS=ac_cv_dnet_linux_procfs=yes ac_cv_dnet_bsd_bpf=no
+    DNET_CONFIGURE_FLAGS:=ac_cv_dnet_linux_procfs=yes ac_cv_dnet_bsd_bpf=no
 endif
 
-$(BUILD)/libdnet/Makefile: build/tools $(BUILD)/libdnet/configure
+$(BUILD)/wpdpack:
+	@echo "Unpacking wpdpack for $(TARGET)"
+	@mkdir -p $(BUILD)
+	@cd $(BUILD); \
+		rm -fr wpdpack; \
+		$(TAR) zxf $(ROOT)/deps/wpdpack.tar.gz
+
+ifneq "$(TARGET)" "mingw"
+    DNET_CONFIGURE_FLAGS:=$(DNET_CONFIGURE_FLAGS) --with-wpdpack=$(BUILD)/wpdpack
+    DNET_DEPS:=$(BUILD)/wpdpack
+endif
+
+$(BUILD)/libdnet/Makefile: build/tools $(BUILD)/libdnet/configure $(DNET_DEPS)
 	@echo "Configuring libdnet for $(TARGET)"
 	@mkdir -p $(BUILD)/libdnet
 	@cd $(BUILD)/libdnet; \

--- a/make/Makefile.mbedtls
+++ b/make/Makefile.mbedtls
@@ -1,4 +1,10 @@
-MBEDTLS_VERSION=2.2.1
+MBEDTLS_VERSION=2.3.0
+
+MBEDTLS_ENV=
+ifneq (,$(findstring mingw,$(TARGET)))
+    MBEDTLS_ENV=WINDOWS=1
+endif
+
 
 $(BUILD)/lib/libmbedtls.a: build/tools
 	@echo "Unpacking mbedtls for $(TARGET)"
@@ -9,7 +15,10 @@ $(BUILD)/lib/libmbedtls.a: build/tools
 		mv mbedtls-$(MBEDTLS_VERSION) mbedtls
 	@echo "Building mbedtls for $(TARGET)"
 	@cd $(BUILD)/mbedtls; \
-		$(ENV) $(MAKE) $(LOGBUILD) ; \
-		$(MAKE_INSTALL) DESTDIR=$(BUILD) $(LOGBUILD)
+		$(ENV) $(MBEDTLS_ENV) make $(LOGBUILD) ; \
+		cp -r library/*.a $(BUILD)/lib ; \
+		cp -r include/mbedtls $(BUILD)/include
+		
+	#$(MBEDTLS_ENV) $(MAKE_INSTALL) DESTDIR=$(BUILD) $(LOGBUILD)
 
 mbedtls: $(BUILD)/lib/libmbedtls.a

--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -21,11 +21,11 @@ $(ROOT)/mettle/configure: deps/README.md
 		autoreconf -i $(LOGBUILD)
 
 $(BUILD)/mettle/Makefile: build/tools $(ROOT)/mettle/configure \
-	$(BUILD)/lib/libdnet.a \
 	$(BUILD)/lib/libeio.a \
 	$(BUILD)/lib/libev.a \
 	$(BUILD)/lib/libmbedtls.a \
-	$(BUILD)/lib/libsigar.a
+	$(BUILD)/lib/libsigar.a \
+	$(BUILD)/lib/libdnet.a
 	@echo "Configuring mettle for $(TARGET)"
 	@mkdir -p $(BUILD)/mettle
 	@cd $(BUILD)/mettle; \

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -1,11 +1,20 @@
 BUILD_HOST=linux
 TOOLCHAIN_VERSION=3
 ifneq "$(TARGET)" "native"
-    CC=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-cc
-    CPP=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-cpp
-    AR=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-ar
-    LD=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-ld
-    RANLIB=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-ranlib
+    ifneq (,$(findstring musl,$(TARGET)))
+        CC=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-gcc
+        CPP=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-cpp
+        AR=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-ar
+        LD=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-ld
+        RANLIB=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-ranlib
+    endif
+    ifneq (,$(findstring mingw,$(TARGET)))
+        CC=$(TARGET)-gcc
+        CPP=$(TARGET)-cpp
+        AR=$(TARGET)-ar
+        LD=$(TARGET)-ld
+        RANLIB=$(TARGET)-ranlib
+    endif
 endif
 
 TAR=tar

--- a/mettle/src/log.c
+++ b/mettle/src/log.c
@@ -148,7 +148,7 @@ void zlog_time(char *filename, int line, char const *fmt, ...)
 	if (zlog_fout) {
 		gettimeofday(&tv, NULL);
 		curtime = tv.tv_sec;
-		strftime(timebuf, 64, "%m-%d-%Y %T", localtime(&curtime));
+		strftime(timebuf, 64, "%m-%d-%Y %H:%M:%S", localtime(&curtime));
 		snprintf(usecbuf, 16, "%.03f", tv.tv_usec / 1000000.0);
 
 		buffer = zlog_get_buffer();

--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -14,10 +14,15 @@
 #include <stdlib.h>
 
 #include <sys/types.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+#else
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <sys/uio.h>
+#endif
 #include <unistd.h>
 
 #include "buffer_queue.h"

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -4,7 +4,11 @@
  * @file tlv.c
  */
 
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 #include <endian.h>
 
 #include <stdarg.h>


### PR DESCRIPTION
This fixes mettle's dependencies so that it can build in Windows / mingw-w64 environments. Deps gets a bump to fix some libeio problems here: https://github.com/busterb/libeio/commit/d5f5eaedebc40f46fecbcc1a4aac98811d1f629c