### PR TITLE
Change rake task to never install mettle

### DIFF
--- a/ARCHES
+++ b/ARCHES
@@ -1,0 +1,10 @@
+aarch64-linux-musl
+armv5l-linux-musleabi
+armv5b-linux-musleabi
+i486-linux-musl
+x86_64-linux-musl
+powerpc-linux-muslsf
+powerpc64le-linux-musl
+mips-linux-muslsf
+mipsel-linux-muslsf
+mips64-linux-muslsf

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,13 @@ namespace :mettle do
 
   desc 'Make mettle for all architectures'
   task :build do
-    system('./make-all')
+    File.readlines('ARCHES').each do |tuple|
+      puts "Building target #{tuple}"
+      unless system "make TARGET=#{tuple}"
+        $stderr.puts "Failed to build #{tuple}"
+        exit false
+      end
+    end
   end
 end
 

--- a/make-all
+++ b/make-all
@@ -2,18 +2,7 @@
 
 set -e
 
-for i in \
-	aarch64-linux-musl \
-	armv5l-linux-musleabi \
-	armv5b-linux-musleabi \
-	i486-linux-musl \
-	x86_64-linux-musl \
-	powerpc-linux-muslsf \
-	powerpc64le-linux-musl \
-	mips-linux-muslsf \
-	mipsel-linux-muslsf \
-	mips64-linux-muslsf \
-	; do
+for i in $(cat ARCHES); do
 	echo Building target $i
 	make TARGET=$i;
 	make TARGET=$i install;


### PR DESCRIPTION
Verification
========
- [ ] `rake` should build all the arches
- [ ] `rake` should not to try to copy stuff to `../metasploit-framework`