### PR TITLE
Remove core_uuid, add core_set_uuid, add UUID to each response

### DIFF
--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -58,18 +58,17 @@ static struct tlv_packet *core_machine_id(struct tlv_handler_ctx *ctx)
 		"%s:%s", mettle_get_fqdn(m), mettle_get_machine_id(m));
 }
 
-static struct tlv_packet *core_uuid(struct tlv_handler_ctx *ctx)
+static struct tlv_packet *core_set_uuid(struct tlv_handler_ctx *ctx)
 {
+	size_t uuid_len = 0;
 	struct mettle *m = ctx->arg;
+	char *uuid = tlv_packet_get_raw(ctx->req, TLV_TYPE_UUID, &uuid_len);
 
-	size_t len;
-	const char *uuid = mettle_get_uuid(m, &len);
-	if (uuid) {
-		struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
-		return tlv_packet_add_raw(p, TLV_TYPE_UUID, uuid, len);
-	} else {
-		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
+	if (uuid && uuid_len) {
+		mettle_set_uuid(m, uuid, uuid_len);
 	}
+
+	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 }
 
 void tlv_register_coreapi(struct mettle *m)
@@ -78,6 +77,6 @@ void tlv_register_coreapi(struct mettle *m)
 
 	tlv_dispatcher_add_handler(td, "core_enumextcmd", enumextcmd, m);
 	tlv_dispatcher_add_handler(td, "core_machine_id", core_machine_id, m);
-	tlv_dispatcher_add_handler(td, "core_uuid", core_uuid, m);
+	tlv_dispatcher_add_handler(td, "core_set_uuid", core_set_uuid, m);
 	tlv_dispatcher_add_handler(td, "core_shutdown", core_shutdown, m);
 }

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -21,6 +21,7 @@
 #include "tlv.h"
 #include "uthash.h"
 #include "utlist.h"
+#include "mettle.h"
 
 struct tlv_xor_header {
 	uint32_t xor_key;
@@ -338,6 +339,15 @@ struct tlv_packet * tlv_packet_response(struct tlv_handler_ctx *ctx)
 	struct tlv_packet *p = tlv_packet_new(TLV_PACKET_TYPE_RESPONSE,
 			tlv_packet_len(ctx->req) + 32);
 	p = tlv_packet_add_str(p, TLV_TYPE_METHOD, ctx->method);
+
+	// UUIDs need to be part of every response now.
+	size_t uuid_len = 0;
+	struct mettle* m = ctx->arg;
+	const char* uuid = mettle_get_uuid(m, &uuid_len);
+	if (uuid && uuid_len) {
+		p = tlv_packet_add_raw(p, TLV_TYPE_UUID, uuid, uuid_len);
+	}
+
 	if (ctx->channel_id) {
 		p = tlv_packet_add_u32(p, TLV_TYPE_CHANNEL_ID, ctx->channel_id);
 	}


### PR DESCRIPTION
This PR (hopefully) brings Mettle up to date with the work done in both https://github.com/rapid7/metasploit-payloads/pull/143 and https://github.com/rapid7/metasploit-framework/pull/7507. Please see the MSF PR for details on what this all means.