### PR TITLE
Add config options to the Ruby API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ To build the gem (currently requires linux):
 rake build
 ```
 
+To check the resulting binaries:
+
+```
+rake check
+```
+
 To completely reset your dev environment and delete all binary artifacts:
 
 ```
@@ -22,9 +28,9 @@ rake mettle:ultraclean
 Gem API
 -------
 
-The gem provides one function for accessing binary payloads:
+To generate a payload with Mettle:
 ```ruby
-MetasploitPayloads::Mettle.read(platform_triple, artifact)
+mettle = MetasploitPayloads::Mettle.new(platform_triple, config={})
 ```
 
 The available platform triples are:
@@ -39,9 +45,25 @@ The available platform triples are:
 * `mipsel-linux-muslsf`
 * `mips64-linux-muslsf`
 
-The available artifacts are:
-* `mettle` - a standalone executable that take command-line arguments (see `mettle -h`)
-* `mettle.bin` - a process image that must be started with a custom stack (see `doc/stack_requirements.md`)
+Available config options are:
+* `:url` - the url to connect back to
+* `:uuid` - the UUID to identify the payload
+* `:debug` - to turn on debug messages
+* `:log_file` - the file to send debug messages to instead of `stderr`
+
+Config options can also be set with:
+```ruby
+mettle.config[:key] = val
+```
+
+To get a binary with installed options call:
+```ruby
+mettle.to_binary(format=:process_image)
+```
+
+The formats are:
+* `:exec` - a standalone executable that can take command-line arguments (see `mettle -h`) or use pre-set ones
+* `:process_image` - a process image that must be started with a custom stack (see `doc/stack_requirements.md`)
 
 
 Using with Metasploit

--- a/doc/stack_requirements.md
+++ b/doc/stack_requirements.md
@@ -9,7 +9,7 @@ Also note that we do not obey the SysV ABI since we have a file descriptor as
 ARGV[1] instead of a `char *`.
 
 ```
-low                      (each cell is one long)
+low                    (each cell is sizeof(void *))
 sp % 16 == 0     +---------------------------------------+
                  |              ARGC = X                 |
                  |---------------------------------------|

--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -57,6 +57,8 @@ module MetasploitPayloads
         'd'
       when :log_file
         'o'
+      else
+        fail RuntimeError, "unknown mettle option #{opt}", caller
       end
     end
 
@@ -91,6 +93,8 @@ module MetasploitPayloads
             'mettle.bin'
           when :exec
             'mettle'
+          else
+            fail RuntimeError, "unknown mettle format #{format}", caller
           end
       file_path = path("#{triple}", 'bin', file)
       if file_path.nil?

--- a/lib/metasploit_payloads/mettle/version.rb
+++ b/lib/metasploit_payloads/mettle/version.rb
@@ -1,6 +1,6 @@
 # -*- coding:binary -*-
 module MetasploitPayloads
-  module Mettle
+  class Mettle
     VERSION = '0.0.9'
 
     def self.version


### PR DESCRIPTION
Note: this breaks how the Ruby API is called.

Verification
========
- [ ] Build gem and install on a Linux box `rake build; gem install pkg/metasploit_payloads-mettle-0.0.9.gem`
- [ ] fire up `irb`
- [ ] run:
```
require 'metasploit_payloads/mettle'
m = MetasploitPayloads::Mettle.new 'x86_64-linux-musl'
m.config[:debug] = true
b = m.to_binary :exec; nil
File.open("/tmp/mettle", "wb") {|f| f.write b}
```
- [ ] Back in the shell `chmod +x /tmp/mettle; /tmp/mettle`
- [ ] You should see the heartbeat debug message