### PR TITLE
update toolchain to gcc 6.2, binutils 2.27, add s390x support

### DIFF
--- a/ARCHES
+++ b/ARCHES
@@ -8,3 +8,4 @@ powerpc64le-linux-musl
 mips-linux-muslsf
 mipsel-linux-muslsf
 mips64-linux-muslsf
+s390x-linux-musl

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -1,5 +1,5 @@
 BUILD_HOST=linux
-TOOLCHAIN_VERSION=3
+TOOLCHAIN_VERSION=4
 ifneq "$(TARGET)" "native"
     ifneq (,$(findstring musl,$(TARGET)))
         CC=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-gcc
@@ -51,4 +51,4 @@ ifneq "$(TARGET)" "native"
 endif
 
 build/tools: $(TOOLS_DEPS)
-	mkdir -p build/tools	
+	mkdir -p build/tools


### PR DESCRIPTION
This just does a toolchain bump to the latest musl snapshot (which includes working s390x support), and grabs the latest gcc and binutils versions. Everything seems to work as before.

A neat thing is the s390 support worked with no changes to mettle itself, and it was even able to distinguish between 31-bit and 64-bit processes in ps:

```
meterpreter > sysinfo
Computer     : s390x.hauschen.net
OS           : Debian 8.6 (Linux 3.16.0-4-s390x)
Architecture : s390x
Meterpreter  : x86/linux
meterpreter > ps

Process List
============

 PID  PPID  Name              Arch   User         Path
 ---  ----  ----              ----   ----         ----
 1    0     systemd           s390x  root         .
 2    0     kthreadd          s390x  root         .
 3    2     ksoftirqd/0       s390x  root         .
 5    2     kworker/0:0H      s390x  root         .
 6    2     kworker/u16:0     s390x  root         .
 7    2     rcu_sched         s390x  root         .
 8    2     rcu_bh            s390x  root         .
 9    2     migration/0       s390x  root         .
 10   2     migration/1       s390x  root         .
 11   2     ksoftirqd/1       s390x  root         .
 13   2     kworker/1:0H      s390x  root         .
 14   2     khelper           s390x  root         .
 15   2     kdevtmpfs         s390x  root         .
 16   2     netns             s390x  root         .
 17   2     khungtaskd        s390x  root         .
 18   2     writeback         s390x  root         .
 19   2     ksmd              s390x  root         .
 20   2     crypto            s390x  root         .
 21   2     kintegrityd       s390x  root         .
 22   2     bioset            s390x  root         .
 23   2     kblockd           s390x  root         .
 24   2     cio               s390x  root         .
 25   2     cio_chp           s390x  root         .
 27   2     kworker/1:1       s390x  root         .
 28   2     kworker/0:1       s390x  root         .
 29   2     cmmthread         s390x  root         .
 30   2     appldata          s390x  root         .
 31   2     kswapd0           s390x  root         .
 32   2     vmstat            s390x  root         .
 33   2     fsnotify_mark     s390x  root         .
 39   2     kthrotld          s390x  root         .
 40   2     kpsmoused         s390x  root         .
 41   2     kmcheck           s390x  root         .
 42   2     ipv6_addrconf     s390x  root         .
 43   2     deferwq           s390x  root         .
 89   2     jbd2/dasda1-8     s390x  root         .
 90   2     ext4-rsv-conver   s390x  root         .
 101  2     kworker/u16:2     s390x  root         .
 123  2     kworker/1:2       s390x  root         .
 130  2     kauditd           s390x  root         .
 140  1     systemd-journald  s390x  root         .
 145  1     systemd-udevd     s390x  root         .
 199  2     jbd2/dasdb1-8     s390x  root         .
 200  2     ext4-rsv-conver   s390x  root         .
 267  1     rpcbind           s390x  root         .
 276  1     rpc.statd         s390x  statd        .
 281  2     rpciod            s390x  root         .
 283  2     nfsiod            s390x  root         .
 290  1     rpc.idmapd        s390x  root         .
 291  1     cron              s390x  root         .
 292  1     atd               s390x  root         .
 293  1     sshd              s390x  root         .
 295  1     systemd-logind    s390x  root         .
 298  1     dbus-daemon       s390x  messagebus   .
 308  1     rsyslogd          s390x  root         .
 344  1     agetty            s390x  root         .
 346  1     agetty            s390x  root         .
 557  1     exim4             s390x  Debian-exim  .
 566  293   sshd              s390x  root         .
 568  566   sshd              s390x  bcook        .
 569  568   bash              s390   bcook        /bin
 593  568   bash              s390   bcook        /bin
 611  2     kworker/0:0       s390x  root         .
 614  593   mettle            s390   bcook        /home/bcook
```