### PR TITLE
leave core_uuid in place, store UUID in tlv dispatcher

### DIFF
--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -62,13 +62,29 @@ static struct tlv_packet *core_set_uuid(struct tlv_handler_ctx *ctx)
 {
 	size_t uuid_len = 0;
 	struct mettle *m = ctx->arg;
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
 	char *uuid = tlv_packet_get_raw(ctx->req, TLV_TYPE_UUID, &uuid_len);
 
 	if (uuid && uuid_len) {
-		mettle_set_uuid(m, uuid, uuid_len);
+		tlv_dispatcher_set_uuid(td, uuid, uuid_len);
 	}
 
 	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
+static struct tlv_packet *core_uuid(struct tlv_handler_ctx *ctx)
+{
+	size_t uuid_len;
+	struct mettle *m = ctx->arg;
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+	const char *uuid = tlv_dispatcher_get_uuid(td, &uuid_len);
+
+	if (uuid && uuid_len) {
+	       struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+	       return tlv_packet_add_raw(p, TLV_TYPE_UUID, uuid, uuid_len);
+	}
+
+	return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 }
 
 void tlv_register_coreapi(struct mettle *m)
@@ -78,5 +94,6 @@ void tlv_register_coreapi(struct mettle *m)
 	tlv_dispatcher_add_handler(td, "core_enumextcmd", enumextcmd, m);
 	tlv_dispatcher_add_handler(td, "core_machine_id", core_machine_id, m);
 	tlv_dispatcher_add_handler(td, "core_set_uuid", core_set_uuid, m);
+	tlv_dispatcher_add_handler(td, "core_uuid", core_uuid, m);
 	tlv_dispatcher_add_handler(td, "core_shutdown", core_shutdown, m);
 }

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -13,7 +13,6 @@
 #include <unistd.h>
 
 #include "argv_split.h"
-#include "base64.h"
 #include "log.h"
 #include "mettle.h"
 
@@ -38,17 +37,6 @@ static void start_logger(const char *out)
 	}
 	log_init_file(l);
 	log_init_flush_thread();
-}
-
-int mettle_set_uuid_base64(struct mettle *m, char *uuid_b64)
-{
-	char *uuid = calloc(1, strlen(uuid_b64));
-	if (uuid == NULL)
-		return -1;
-	int len = base64decode(uuid, uuid_b64, strlen(uuid_b64));
-	mettle_set_uuid(m, uuid, len);
-	free(uuid);
-	return 0;
 }
 
 static int parse_cmdline(int argc, char * const argv[], struct mettle *m)

--- a/mettle/src/mettle.h
+++ b/mettle/src/mettle.h
@@ -21,9 +21,7 @@ const char *mettle_get_fqdn(struct mettle *m);
 
 const char *mettle_get_machine_id(struct mettle *m);
 
-const char *mettle_get_uuid(struct mettle *m, size_t *len);
-
-int mettle_set_uuid(struct mettle *m, char *uuid, size_t len);
+int mettle_set_uuid_base64(struct mettle *m, char *uuid_b64);
 
 sigar_t *mettle_get_sigar(struct mettle *m);
 

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -132,6 +132,10 @@ void tlv_dispatcher_iter_extension_methods(struct tlv_dispatcher *td,
 		const char *extension,
 		void (*cb)(const char *method, void *arg), void *arg);
 
+const char *tlv_dispatcher_get_uuid(struct tlv_dispatcher *td, size_t *len);
+
+int tlv_dispatcher_set_uuid(struct tlv_dispatcher *td, char *uuid, size_t len);
+
 void tlv_dispatcher_free(struct tlv_dispatcher *td);
 
 struct mettle;


### PR DESCRIPTION
This fixes forward/backward compatibility with mettle payloads in Metasploit-framework. It also fixes a segfault that occurs generating any packet response since the context is not guaranteed or required to be a pointer to the 'mettle' object, so this moves the UUID to the tlv_dispatcher object.