### PR TITLE
Network channel support

### DIFF
--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -13,6 +13,7 @@ libmettle_la_LIBADD += -lsigar
 libmettle_la_SOURCES = mettle.c
 libmettle_la_SOURCES += argv_split.c
 libmettle_la_SOURCES += base64.c
+libmettle_la_SOURCES += bufferev.c
 libmettle_la_SOURCES += buffer_queue.c
 libmettle_la_SOURCES += channel.c
 libmettle_la_SOURCES += log.c

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -18,6 +18,7 @@ libmettle_la_SOURCES += buffer_queue.c
 libmettle_la_SOURCES += channel.c
 libmettle_la_SOURCES += log.c
 libmettle_la_SOURCES += network_client.c
+libmettle_la_SOURCES += network_server.c
 libmettle_la_SOURCES += tlv.c
 libmettle_la_SOURCES += coreapi.c
 libmettle_la_SOURCES += stdapi/stdapi.c

--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -39,8 +39,6 @@ struct bufferev {
 	int sock, connected;
 	struct ev_io data_ev;
 
-	struct addrinfo *addrinfo;
-
 	struct buffer_queue *tx_queue;
 	struct buffer_queue *rx_queue;
 

--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -42,14 +42,10 @@ struct bufferev {
 	struct buffer_queue *tx_queue;
 	struct buffer_queue *rx_queue;
 
-	bufferev_cb_t connect_cb;
-	void *connect_cb_arg;
-	bufferev_cb_t read_cb;
-	void *read_cb_arg;
-	bufferev_cb_t error_cb;
-	void *error_cb_arg;
-	bufferev_cb_t close_cb;
-	void *close_cb_arg;
+	bufferev_data_cb read_cb;
+	bufferev_data_cb write_cb;
+	bufferev_event_cb event_cb;
+	void *cb_arg;
 
 	char *host;
 	char **services;
@@ -87,32 +83,16 @@ network_str_to_proto(const char *proto)
 	return network_proto_tcp;
 }
 
-void bufferev_set_read_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg)
+void bufferev_setcbs(struct bufferev *be,
+	bufferev_data_cb read_cb,
+	bufferev_data_cb write_cb,
+	bufferev_event_cb event_cb,
+	void *cb_arg)
 {
-    be->read_cb = cb;
-    be->read_cb_arg = arg;
-}
-
-void bufferev_set_connect_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg)
-{
-    be->connect_cb = cb;
-    be->connect_cb_arg = arg;
-}
-
-void bufferev_set_error_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg)
-{
-    be->error_cb = cb;
-    be->error_cb_arg = arg;
-}
-
-void bufferev_set_close_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg)
-{
-    be->close_cb = cb;
-    be->close_cb_arg = arg;
+    be->read_cb = read_cb;
+    be->write_cb = write_cb;
+    be->event_cb = event_cb;
+    be->cb_arg = cb_arg;
 }
 
 struct buffer_queue * bufferev_rx_queue(struct bufferev *be)
@@ -172,14 +152,14 @@ on_read(struct ev_loop *loop, struct ev_io *w, int events)
 		bytes_read += rc;
 		buffer_queue_add(be->rx_queue, buf, rc);
 		if (be->read_cb) {
-			be->read_cb(be, be->read_cb_arg);
+			be->read_cb(be, be->cb_arg);
 		}
 	}
 
 	if (bytes_read <= 0) {
 		ev_io_stop(be->loop, &be->data_ev);
-		if (be->close_cb) {
-			be->close_cb(be, be->close_cb_arg);
+		if (be->event_cb) {
+			be->event_cb(be, BEV_EOF, be->cb_arg);
 		}
 	}
 }
@@ -204,8 +184,8 @@ on_connect_timeout(struct ev_loop *loop, struct ev_timer *w, int revents)
 		close_sock(be);
 		ev_io_stop(be->loop, &be->data_ev);
 
-		if (be->error_cb) {
-			be->error_cb(be, be->error_cb_arg);
+		if (be->event_cb) {
+			be->event_cb(be, BEV_ERROR | BEV_TIMEOUT, be->cb_arg);
 		}
 	}
 }
@@ -222,14 +202,14 @@ on_connect(struct ev_loop *loop, struct ev_io *w, int events)
 	socklen_t len = sizeof(status);
 	getsockopt(be->sock, SOL_SOCKET, SO_ERROR, &status, &len);
 	if (status != 0) {
-		if (be->error_cb) {
-			be->error_cb(be, be->error_cb_arg);
+		if (be->event_cb) {
+			be->event_cb(be, BEV_ERROR, be->cb_arg);
 		}
 		return;
 	}
 
-	if (be->connect_cb) {
-		be->connect_cb(be, be->connect_cb_arg);
+	if (be->event_cb) {
+		be->event_cb(be, BEV_CONNECTED, be->cb_arg);
 	}
 
 	ev_io_init(&be->data_ev, on_read, be->sock, EV_READ);
@@ -242,8 +222,8 @@ int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai, float ti
 {
 	be->sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 	if (be->sock < 0) {
-		if (be->error_cb) {
-			be->error_cb(be, be->error_cb_arg);
+		if (be->event_cb) {
+			be->event_cb(be, BEV_ERROR, be->cb_arg);
 		}
 		return -1;
 	}
@@ -266,8 +246,8 @@ int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai, float ti
 		ev_timer_start(be->loop, &be->connect_timer);
 	} else {
 		close_sock(be);
-		if (be->error_cb) {
-			be->error_cb(be, be->error_cb_arg);
+		if (be->event_cb) {
+			be->event_cb(be, BEV_ERROR, be->cb_arg);
 		}
 		return -1;
 	}
@@ -286,10 +266,53 @@ int bufferev_connect_tcp_sock(struct bufferev *be, int sock)
 	be->data_ev.data = be;
 	ev_io_start(be->loop, &be->data_ev);
 
-	if (be->connect_cb) {
-		be->connect_cb(be, be->connect_cb_arg);
+	if (be->event_cb) {
+		be->event_cb(be, BEV_CONNECTED, be->cb_arg);
 	}
+
 	return 0;
+}
+
+static char *
+parse_sockaddr(struct sockaddr_storage *addr, uint16_t *port)
+{
+	char host[INET6_ADDRSTRLEN] = { 0 };
+
+	if (addr->ss_family == AF_INET) {
+		struct sockaddr_in *s = (struct sockaddr_in *)&addr;
+		*port = ntohs(s->sin_port);
+		inet_ntop(AF_INET, &s->sin_addr, host, INET6_ADDRSTRLEN);
+	} else if (addr->ss_family == AF_INET6) {
+		struct sockaddr_in6 *s = (struct sockaddr_in6 *)&addr;
+		*port = ntohs(s->sin6_port);
+		inet_ntop(AF_INET6, &s->sin6_addr, host, INET6_ADDRSTRLEN);
+	}
+
+	return strdup(host);
+}
+
+char * bufferev_get_local_addr(struct bufferev *be, uint16_t *port)
+{
+	struct sockaddr_storage addr;
+	socklen_t len = sizeof(addr);
+
+	if (getsockname(be->sock, (struct sockaddr *)&addr, &len) == -1) {
+		return NULL;
+	}
+
+	return parse_sockaddr(&addr, port);
+}
+
+char * bufferev_get_peer_addr(struct bufferev *be, uint16_t *port)
+{
+	struct sockaddr_storage addr;
+	socklen_t len = sizeof(addr);
+
+	if (getpeername(be->sock, (struct sockaddr *)&addr, &len) == -1) {
+		return NULL;
+	}
+
+	return parse_sockaddr(&addr, port);
 }
 
 void bufferev_free(struct bufferev *be)

--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -1,0 +1,288 @@
+/**
+ * Copyright 2015 Rapid7
+ * @brief Durable multi-transport client network connection
+ * @file network-client.h
+ */
+
+#include <ev.h>
+#include <eio.h>
+#include <errno.h>
+#include <string.h>
+#include <strings.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <sys/types.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+#else
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <sys/uio.h>
+#endif
+#include <unistd.h>
+
+#include "buffer_queue.h"
+#include "log.h"
+#include "bufferev.h"
+#include "util.h"
+
+struct bufferev {
+	struct ev_loop *loop;
+
+	char *uri;
+	enum network_proto proto;
+	int sock;
+	struct ev_io data_ev;
+
+	struct addrinfo *addrinfo;
+
+	struct buffer_queue *tx_queue;
+	struct buffer_queue *rx_queue;
+
+	bufferev_cb_t connect_cb;
+	void *connect_cb_arg;
+	bufferev_cb_t read_cb;
+	void *read_cb_arg;
+	bufferev_cb_t error_cb;
+	void *error_cb_arg;
+	bufferev_cb_t close_cb;
+	void *close_cb_arg;
+
+	char *host;
+	char **services;
+	int num_services;
+};
+
+struct {
+	enum network_proto proto;
+	const char *str;
+} proto_list[] = {
+	{network_proto_udp, "udp"},
+	{network_proto_tcp, "tcp"},
+	{network_proto_tcp, "tls"},
+};
+
+const char
+*network_proto_to_str(enum network_proto proto)
+{
+	for (int i = 0; i < COUNT_OF(proto_list); i++) {
+		if (proto_list[i].proto == proto) {
+			return proto_list[i].str;
+		}
+	}
+	return "unknown";
+}
+
+enum network_proto
+network_str_to_proto(const char *proto)
+{
+	for (int i = 0; i < COUNT_OF(proto_list); i++) {
+		if (!strcasecmp(proto_list[i].str, proto)) {
+			return proto_list[i].proto;
+		}
+	}
+	return network_proto_tcp;
+}
+
+void bufferev_set_read_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg)
+{
+    be->read_cb = cb;
+    be->read_cb_arg = arg;
+}
+
+void bufferev_set_connect_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg)
+{
+    be->connect_cb = cb;
+    be->connect_cb_arg = arg;
+}
+
+void bufferev_set_error_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg)
+{
+    be->error_cb = cb;
+    be->error_cb_arg = arg;
+}
+
+void bufferev_set_close_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg)
+{
+    be->close_cb = cb;
+    be->close_cb_arg = arg;
+}
+
+struct buffer_queue * bufferev_rx_queue(struct bufferev *be)
+{
+	return be->rx_queue;
+}
+
+size_t bufferev_bytes_available(struct bufferev *be)
+{
+	return buffer_queue_len(be->rx_queue);
+}
+
+size_t bufferev_peek(struct bufferev *be, void *buf, size_t buflen)
+{
+	return buffer_queue_copy(be->rx_queue, buf, buflen);
+}
+
+size_t bufferev_read(struct bufferev *be, void *buf, size_t buflen)
+{
+	return buffer_queue_remove(be->rx_queue, buf, buflen);
+}
+
+ssize_t bufferev_write(struct bufferev *be, void *buf, size_t buflen)
+{
+	ssize_t off = 0, rc;
+	ssize_t sent_bytes = 0;
+
+	switch (be->proto) {
+	case network_proto_udp:
+		return send(be->sock, buf, buflen, 0);
+	case network_proto_tcp:
+		do {
+			rc = send(be->sock, buf + off, buflen - off, 0);
+			if (rc > 0) {
+				off += rc;
+				sent_bytes += rc;
+			}
+		} while (rc > 0 || (rc < 0 && (errno == EAGAIN || errno == EINTR)));
+		return sent_bytes;
+
+	case network_proto_tls:
+		return buffer_queue_add(be->tx_queue, buf, buflen);
+	}
+
+	return -1;
+}
+
+void on_read(struct ev_loop *loop, struct ev_io *w, int events)
+{
+	struct bufferev *be = w->data;
+
+	ssize_t bytes_read = 0;
+	char buf[4096];
+	ssize_t rc;
+	while ((rc = recv(be->sock, buf, sizeof(buf), 0)) > 0) {
+		bytes_read += rc;
+		buffer_queue_add(be->rx_queue, buf, rc);
+		if (be->read_cb) {
+			be->read_cb(be, be->read_cb_arg);
+		}
+	}
+
+	if (bytes_read <= 0) {
+		ev_io_stop(be->loop, &be->data_ev);
+		if (be->close_cb) {
+			be->close_cb(be, be->close_cb_arg);
+		}
+	}
+}
+
+static void
+on_connect(struct ev_loop *loop, struct ev_io *w, int events)
+{
+	struct bufferev *be = w->data;
+
+	ev_io_stop(be->loop, &be->data_ev);
+
+	int status;
+	socklen_t len = sizeof(status);
+	getsockopt(be->sock, SOL_SOCKET, SO_ERROR, &status, &len);
+	if (status != 0) {
+		if (be->error_cb) {
+			be->error_cb(be, be->error_cb_arg);
+		}
+		return;
+	}
+
+	if (be->connect_cb) {
+		be->connect_cb(be, be->connect_cb_arg);
+	}
+
+	ev_io_init(&be->data_ev, on_read, be->sock, EV_READ);
+	be->data_ev.data = be;
+	ev_io_start(be->loop, &be->data_ev);
+}
+
+int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai)
+{
+	be->sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+	if (be->sock < 0) {
+		return -1;
+	}
+
+	make_socket_nonblocking(be->sock);
+
+	if (ai->ai_protocol == IPPROTO_UDP) {
+		be->proto = network_proto_udp;
+	} else {
+		be->proto = network_proto_tcp;
+	}
+
+	int rc = connect(be->sock, ai->ai_addr, ai->ai_addrlen);
+	if (rc == 0 || errno == EINPROGRESS) {
+		ev_io_init(&be->data_ev, on_connect, be->sock, EV_WRITE);
+		be->data_ev.data = be;
+		ev_io_start(be->loop, &be->data_ev);
+	}
+	return 0;
+}
+
+int bufferev_connect_tcp_sock(struct bufferev *be, int sock)
+{
+	be->proto = network_proto_tcp;
+
+	make_socket_nonblocking(be->sock);
+	be->sock = sock;
+
+	ev_io_init(&be->data_ev, on_read, be->sock, EV_READ);
+	be->data_ev.data = be;
+	ev_io_start(be->loop, &be->data_ev);
+
+	if (be->connect_cb) {
+		be->connect_cb(be, be->connect_cb_arg);
+	}
+	return 0;
+}
+
+void bufferev_free(struct bufferev *be)
+{
+	if (be) {
+		ev_io_stop(be->loop, &be->data_ev);
+		buffer_queue_free(be->rx_queue);
+		buffer_queue_free(be->tx_queue);
+		free(be);
+	}
+}
+
+struct bufferev * bufferev_new(struct ev_loop *loop)
+{
+	struct bufferev *be = calloc(1, sizeof(*be));
+	if (!be) {
+		return NULL;
+	}
+
+	be->rx_queue = buffer_queue_new();
+	if (be->rx_queue == NULL) {
+		goto err;
+	}
+
+	be->tx_queue = buffer_queue_new();
+	if (be->tx_queue == NULL) {
+		goto err;
+	}
+
+	be->loop = loop;
+
+	return be;
+
+err:
+	bufferev_free(be);
+	return NULL;
+}

--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -236,10 +236,11 @@ int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai)
 
 int bufferev_connect_tcp_sock(struct bufferev *be, int sock)
 {
-	be->proto = network_proto_tcp;
+	be->sock = sock;
 
 	make_socket_nonblocking(be->sock);
-	be->sock = sock;
+
+	be->proto = network_proto_tcp;
 
 	ev_io_init(&be->data_ev, on_read, be->sock, EV_READ);
 	be->data_ev.data = be;

--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -223,9 +223,6 @@ int bufferev_connect_addrinfo(struct bufferev *be,
 {
 	be->sock = socket(dst->ai_family, dst->ai_socktype, dst->ai_protocol);
 	if (be->sock < 0) {
-		if (be->event_cb) {
-			be->event_cb(be, BEV_ERROR, be->cb_arg);
-		}
 		return -1;
 	}
 
@@ -250,9 +247,6 @@ int bufferev_connect_addrinfo(struct bufferev *be,
 		ev_timer_start(be->loop, &be->connect_timer);
 	} else {
 		close_sock(be);
-		if (be->event_cb) {
-			be->event_cb(be, BEV_ERROR, be->cb_arg);
-		}
 		return -1;
 	}
 	return 0;

--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -160,7 +160,8 @@ ssize_t bufferev_write(struct bufferev *be, void *buf, size_t buflen)
 	return -1;
 }
 
-void on_read(struct ev_loop *loop, struct ev_io *w, int events)
+static void
+on_read(struct ev_loop *loop, struct ev_io *w, int events)
 {
 	struct bufferev *be = w->data;
 
@@ -183,7 +184,8 @@ void on_read(struct ev_loop *loop, struct ev_io *w, int events)
 	}
 }
 
-static void close_sock(struct bufferev *be)
+static void
+close_sock(struct bufferev *be)
 {
 	if (be->sock >= 0) {
 		close(be->sock);

--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -214,6 +214,9 @@ int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai)
 {
 	be->sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 	if (be->sock < 0) {
+		if (be->error_cb) {
+			be->error_cb(be, be->error_cb_arg);
+		}
 		return -1;
 	}
 
@@ -230,6 +233,12 @@ int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai)
 		ev_io_init(&be->data_ev, on_connect, be->sock, EV_WRITE);
 		be->data_ev.data = be;
 		ev_io_start(be->loop, &be->data_ev);
+	} else {
+		close(be->sock);
+		if (be->error_cb) {
+			be->error_cb(be, be->error_cb_arg);
+		}
+		return -1;
 	}
 	return 0;
 }

--- a/mettle/src/bufferev.h
+++ b/mettle/src/bufferev.h
@@ -29,19 +29,21 @@ int bufferev_connect_tcp_sock(struct bufferev *be, int sock);
 int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai,
 	float timeout_s);
 
-typedef void (*bufferev_cb_t)(struct bufferev *be, void *arg);
+#define BEV_READING   0x01  // error encountered while reading
+#define BEV_WRITING   0x02  // error encountered while writing
+#define BEV_EOF       0x04  // end of file reached
+#define BEV_ERROR     0x08  // unrecoverable error encountered
+#define BEV_TIMEOUT   0x10  // user-specified timeout reached
+#define BEV_CONNECTED 0x20  // connect operation finished
 
-void bufferev_set_connect_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg);
+typedef void (*bufferev_data_cb)(struct bufferev *be, void *arg);
+typedef void (*bufferev_event_cb)(struct bufferev *be, int event, void *arg);
 
-void bufferev_set_read_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg);
-
-void bufferev_set_error_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg);
-
-void bufferev_set_close_cb(struct bufferev *be,
-    bufferev_cb_t cb, void *arg);
+void bufferev_setcbs(struct bufferev *be,
+	bufferev_data_cb read_cb,
+	bufferev_data_cb write_cb,
+	bufferev_event_cb event_cb,
+	void *cb_arg);
 
 struct buffer_queue * bufferev_rx_queue(struct bufferev *be);
 
@@ -52,6 +54,10 @@ size_t bufferev_read(struct bufferev *be, void *buf, size_t buflen);
 size_t bufferev_bytes_available(struct bufferev *be);
 
 ssize_t bufferev_write(struct bufferev *be, void *buf, size_t buflen);
+
+char * bufferev_get_local_addr(struct bufferev *be, uint16_t *port);
+
+char * bufferev_get_peer_addr(struct bufferev *be, uint16_t *port);
 
 void bufferev_free(struct bufferev *be);
 

--- a/mettle/src/bufferev.h
+++ b/mettle/src/bufferev.h
@@ -26,7 +26,8 @@ struct bufferev * bufferev_new(struct ev_loop *loop);
 
 int bufferev_connect_tcp_sock(struct bufferev *be, int sock);
 
-int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai);
+int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai,
+	float timeout_s);
 
 typedef void (*bufferev_cb_t)(struct bufferev *be, void *arg);
 

--- a/mettle/src/bufferev.h
+++ b/mettle/src/bufferev.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 Rapid7
+ * @file bufferev.h
+ */
+
+#ifndef _BUFFEREV_H_
+#define _BUFFEREV_H_
+
+#include <ev.h>
+
+#include "buffer_queue.h"
+
+enum network_proto {
+	network_proto_udp,
+	network_proto_tcp,
+	network_proto_tls,
+};
+
+const char *network_proto_to_str(enum network_proto proto);
+
+enum network_proto network_str_to_proto(const char *proto);
+
+struct bufferev;
+
+struct bufferev * bufferev_new(struct ev_loop *loop);
+
+int bufferev_connect_tcp_sock(struct bufferev *be, int sock);
+
+int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai);
+
+typedef void (*bufferev_cb_t)(struct bufferev *be, void *arg);
+
+void bufferev_set_connect_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg);
+
+void bufferev_set_read_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg);
+
+void bufferev_set_error_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg);
+
+void bufferev_set_close_cb(struct bufferev *be,
+    bufferev_cb_t cb, void *arg);
+
+struct buffer_queue * bufferev_rx_queue(struct bufferev *be);
+
+size_t bufferev_peek(struct bufferev *be, void *buf, size_t buflen);
+
+size_t bufferev_read(struct bufferev *be, void *buf, size_t buflen);
+
+size_t bufferev_bytes_available(struct bufferev *be);
+
+ssize_t bufferev_write(struct bufferev *be, void *buf, size_t buflen);
+
+void bufferev_free(struct bufferev *be);
+
+#endif

--- a/mettle/src/bufferev.h
+++ b/mettle/src/bufferev.h
@@ -26,8 +26,8 @@ struct bufferev * bufferev_new(struct ev_loop *loop);
 
 int bufferev_connect_tcp_sock(struct bufferev *be, int sock);
 
-int bufferev_connect_addrinfo(struct bufferev *be, struct addrinfo *ai,
-	float timeout_s);
+int bufferev_connect_addrinfo(struct bufferev *be,
+	struct addrinfo *src_addr, struct addrinfo *dst_addr, float timeout_s);
 
 #define BEV_READING   0x01  // error encountered while reading
 #define BEV_WRITING   0x02  // error encountered while writing

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -112,14 +112,30 @@ struct channel_callbacks * channel_get_callbacks(struct channel *c)
 	return &c->type->cbs;
 }
 
+static struct tlv_packet * new_request(struct channel *c, const char *method, size_t len)
+{
+	struct tlv_packet *p = tlv_packet_new(TLV_PACKET_TYPE_REQUEST, len + 64);
+	if (p) {
+		size_t uuid_len = 0;
+		const char* uuid = tlv_dispatcher_get_uuid(c->cm->td, &uuid_len);
+		if (uuid && uuid_len) {
+			p = tlv_packet_add_raw(p, TLV_TYPE_UUID, uuid, uuid_len);
+		}
+		p = tlv_packet_add_fmt(p, TLV_TYPE_METHOD, "core_channel_%s", method);
+		p = tlv_packet_add_fmt(p, TLV_TYPE_REQUEST_ID,
+				"channel-req-%d", channel_get_id(c));
+		p = tlv_packet_add_u32(p, TLV_TYPE_CHANNEL_ID, channel_get_id(c));
+	}
+	return p;
+}
+
 static int send_write_request(struct channel *c, void *buf, size_t buf_len)
 {
-	struct tlv_packet *p = tlv_packet_new(TLV_PACKET_TYPE_REQUEST, buf_len + 64);
-	p = tlv_packet_add_str(p, TLV_TYPE_METHOD, "core_channel_write");
-	p = tlv_packet_add_fmt(p, TLV_TYPE_REQUEST_ID, "channel-req-%d", channel_get_id(c));
-	p = tlv_packet_add_u32(p, TLV_TYPE_CHANNEL_ID, channel_get_id(c));
+	struct tlv_packet *p = new_request(c, "write", buf_len);
 	p = tlv_packet_add_raw(p, TLV_TYPE_CHANNEL_DATA, buf, buf_len);
 	p = tlv_packet_add_u32(p, TLV_TYPE_LENGTH, buf_len);
+	log_debug("sending write request on channel %u for %zu bytes",
+			channel_get_id(c), buf_len);
 	return tlv_dispatcher_enqueue_response(c->cm->td, p);
 };
 
@@ -155,10 +171,7 @@ size_t channel_queue_len(struct channel *c)
 
 int channel_send_close_request(struct channel *c)
 {
-	struct tlv_packet *p = tlv_packet_new(TLV_PACKET_TYPE_REQUEST, 64);
-	p = tlv_packet_add_str(p, TLV_TYPE_METHOD, "core_channel_close");
-	p = tlv_packet_add_fmt(p, TLV_TYPE_REQUEST_ID, "channel-req-%d", channel_get_id(c));
-	p = tlv_packet_add_u32(p, TLV_TYPE_CHANNEL_ID, channel_get_id(c));
+	struct tlv_packet *p = new_request(c, "close", 0);
 	return tlv_dispatcher_enqueue_response(c->cm->td, p);
 };
 
@@ -221,7 +234,7 @@ static struct tlv_packet *channel_open(struct tlv_handler_ctx *ctx)
 	return p;
 }
 
-static struct channel * get_channel_by_id(struct tlv_handler_ctx *ctx)
+struct channel * tlv_handler_ctx_channel_by_id(struct tlv_handler_ctx *ctx)
 {
 	struct mettle *m = ctx->arg;
 	struct channelmgr *cm = mettle_get_channelmgr(m);
@@ -235,7 +248,7 @@ static struct channel * get_channel_by_id(struct tlv_handler_ctx *ctx)
 
 static struct tlv_packet *channel_close(struct tlv_handler_ctx *ctx)
 {
-	struct channel *c = get_channel_by_id(ctx);
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
 	if (c == NULL) {
 		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}
@@ -252,35 +265,43 @@ static struct tlv_packet *channel_close(struct tlv_handler_ctx *ctx)
 	return p;
 }
 
+void channel_set_interactive(struct channel *c, bool enable)
+{
+	if (enable) {
+		struct channel_callbacks *cbs = channel_get_callbacks(c);
+		char buf[65535];
+		size_t buf_len = 0;
+		do {
+			buf_len = cbs->read_cb(c, buf, sizeof(buf));
+			if (buf_len) {
+				send_write_request(c, buf, buf_len);
+			}
+		} while (buf_len > 0);
+	}
+
+	c->interactive = enable;
+}
+
+
 static struct tlv_packet *channel_interact(struct tlv_handler_ctx *ctx)
 {
-	struct channel *c = get_channel_by_id(ctx);
+	bool enable = false;
+	tlv_packet_get_bool(ctx->req, TLV_TYPE_BOOL, &enable);
+
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
 	if (c == NULL) {
 		/*
 		 * We don't care if the caller tells us to stop interacting
 		 * with a non-existent channel.
 		 */
-		bool enable = false;
-		tlv_packet_get_bool(ctx->req, TLV_TYPE_BOOL, &enable);
 		return tlv_packet_response_result(ctx,
 			enable ? TLV_RESULT_FAILURE : TLV_RESULT_SUCCESS);
 	}
 
-	struct channel_callbacks *cbs = channel_get_callbacks(c);
-
-	tlv_packet_get_bool(ctx->req, TLV_TYPE_BOOL, &c->interactive);
+	channel_set_interactive(c, enable);
 
 	tlv_dispatcher_enqueue_response(c->cm->td,
 		tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS));
-
-	char buf[65535];
-	size_t buf_len = 0;
-	do {
-		buf_len = cbs->read_cb(c, buf, sizeof(buf));
-		if (buf_len) {
-			send_write_request(c, buf, buf_len);
-		}
-	} while (buf_len > 0);
 
 	channel_postcb(c);
 
@@ -289,7 +310,7 @@ static struct tlv_packet *channel_interact(struct tlv_handler_ctx *ctx)
 
 static struct tlv_packet *channel_eof(struct tlv_handler_ctx *ctx)
 {
-	struct channel *c = get_channel_by_id(ctx);
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
 	if (c == NULL) {
 		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}
@@ -311,7 +332,7 @@ static struct tlv_packet *channel_eof(struct tlv_handler_ctx *ctx)
 
 static struct tlv_packet *channel_seek(struct tlv_handler_ctx *ctx)
 {
-	struct channel *c = get_channel_by_id(ctx);
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
 	if (c == NULL) {
 		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}
@@ -340,7 +361,7 @@ static struct tlv_packet *channel_seek(struct tlv_handler_ctx *ctx)
 
 static struct tlv_packet *channel_tell(struct tlv_handler_ctx *ctx)
 {
-	struct channel *c = get_channel_by_id(ctx);
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
 	if (c == NULL) {
 		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}
@@ -367,7 +388,7 @@ static struct tlv_packet *channel_tell(struct tlv_handler_ctx *ctx)
 
 static struct tlv_packet *channel_read(struct tlv_handler_ctx *ctx)
 {
-	struct channel *c = get_channel_by_id(ctx);
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
 	if (c == NULL) {
 		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}
@@ -405,7 +426,7 @@ static struct tlv_packet *channel_read(struct tlv_handler_ctx *ctx)
 
 static struct tlv_packet *channel_write(struct tlv_handler_ctx *ctx)
 {
-	struct channel *c = get_channel_by_id(ctx);
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
 	if (c == NULL) {
 		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -451,7 +451,7 @@ static struct tlv_packet *channel_write(struct tlv_handler_ctx *ctx)
 
 	ssize_t bytes_written = cbs->write_cb(c, buf, len);
 	struct tlv_packet *p;
-	if (bytes_written > 0) {
+	if (len == 0 || bytes_written > 0) {
 		p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 		p = tlv_packet_add_u32(p, TLV_TYPE_LENGTH, bytes_written);
 	} else {

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -16,6 +16,7 @@ struct channel {
 	struct buffer_queue *queue;
 	bool interactive;
 	bool shutting_down;
+	bool started;
 };
 
 struct channel_type {
@@ -106,7 +107,16 @@ void channel_set_ctx(struct channel *c, void *ctx)
 
 void channel_shutdown(struct channel *c)
 {
-	c->shutting_down = true;
+	if (c->started) {
+		c->shutting_down = true;
+	} else {
+		channel_free(c);
+	}
+}
+
+void channel_opened(struct channel *c)
+{
+	c->started = true;
 }
 
 struct channel_callbacks * channel_get_callbacks(struct channel *c)
@@ -247,6 +257,7 @@ static struct tlv_packet *channel_open(struct tlv_handler_ctx *ctx)
 		channel_free(c);
 		goto out;
 	} else {
+		c->started = true;
 		rc = TLV_RESULT_SUCCESS;
 	}
 

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -128,11 +128,7 @@ static struct tlv_packet * new_request(struct channel *c, const char *method, si
 {
 	struct tlv_packet *p = tlv_packet_new(TLV_PACKET_TYPE_REQUEST, len + 64);
 	if (p) {
-		size_t uuid_len = 0;
-		const char* uuid = tlv_dispatcher_get_uuid(c->cm->td, &uuid_len);
-		if (uuid && uuid_len) {
-			p = tlv_packet_add_raw(p, TLV_TYPE_UUID, uuid, uuid_len);
-		}
+		p = tlv_packet_add_uuid(p, c->cm->td);
 		p = tlv_packet_add_fmt(p, TLV_TYPE_METHOD, "core_channel_%s", method);
 		p = tlv_packet_add_fmt(p, TLV_TYPE_REQUEST_ID,
 				"channel-req-%d", channel_get_id(c));
@@ -146,8 +142,6 @@ static int send_write_request(struct channel *c, void *buf, size_t buf_len)
 	struct tlv_packet *p = new_request(c, "write", buf_len);
 	p = tlv_packet_add_raw(p, TLV_TYPE_CHANNEL_DATA, buf, buf_len);
 	p = tlv_packet_add_u32(p, TLV_TYPE_LENGTH, buf_len);
-	log_debug("sending write request on channel %u for %zu bytes",
-			channel_get_id(c), buf_len);
 	return tlv_dispatcher_enqueue_response(c->cm->td, p);
 };
 
@@ -491,6 +485,11 @@ static struct tlv_packet *channel_write(struct tlv_handler_ctx *ctx)
 	channel_postcb(c);
 
 	return p;
+}
+
+struct channelmgr *channel_get_channelmgr(struct channel *c)
+{
+	return c->cm;
 }
 
 void tlv_register_channelapi(struct mettle *m)

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -55,6 +55,7 @@ struct channel * channelmgr_channel_new(struct channelmgr *cm, char *channel_typ
 	struct channel_type *ct = channelmgr_type_by_name(cm, channel_type);
 	if (ct == NULL) {
 		log_info("could not find handlers for channel type %s", channel_type);
+		return NULL;
 	}
 
 	struct channel *c = calloc(1, sizeof(*c));

--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -74,6 +74,8 @@ size_t channel_queue_len(struct channel *c);
 
 void channel_shutdown(struct channel *c);
 
+void channel_opened(struct channel *c);
+
 void tlv_register_channelapi(struct mettle *m);
 
 #endif

--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -60,6 +60,8 @@ struct channel_callbacks * channel_get_callbacks(struct channel *c);
 
 void channel_set_interactive(struct channel *c, bool enable);
 
+int channel_send_close_request(struct channel *c);
+
 int channel_enqueue(struct channel *c, void *buf, size_t buf_len);
 
 int channel_enqueue_buffer_queue(struct channel *c, struct buffer_queue *bq);

--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -76,6 +76,8 @@ void channel_shutdown(struct channel *c);
 
 void channel_opened(struct channel *c);
 
+struct channelmgr *channel_get_channelmgr(struct channel *c);
+
 void tlv_register_channelapi(struct mettle *m);
 
 #endif

--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -25,7 +25,9 @@ struct channel * channelmgr_channel_new(struct channelmgr *cm,
 
 void channel_free(struct channel *c);
 
-struct channel *channelmgr_channel_by_id(struct channelmgr *cm, uint32_t id);
+struct channel * channelmgr_channel_by_id(struct channelmgr *cm, uint32_t id);
+
+struct channel * tlv_handler_ctx_channel_by_id(struct tlv_handler_ctx *ctx);
 
 struct channel_callbacks {
 	int (*new_cb)(struct tlv_handler_ctx *tlv_ctx, struct channel *c);
@@ -55,6 +57,8 @@ void * channel_get_ctx(struct channel *c);
 void channel_set_ctx(struct channel *c, void *ctx);
 
 struct channel_callbacks * channel_get_callbacks(struct channel *c);
+
+void channel_set_interactive(struct channel *c, bool enable);
 
 int channel_enqueue(struct channel *c, void *buf, size_t buf_len);
 

--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -32,6 +32,8 @@ struct channel * tlv_handler_ctx_channel_by_id(struct tlv_handler_ctx *ctx);
 struct channel_callbacks {
 	int (*new_cb)(struct tlv_handler_ctx *tlv_ctx, struct channel *c);
 
+	int (*new_async_cb)(struct tlv_handler_ctx *tlv_ctx, struct channel *c);
+
 	ssize_t (*read_cb)(struct channel *c, void *buf, size_t len);
 
 	ssize_t (*write_cb)(struct channel *c, void *buf, size_t len);

--- a/mettle/src/log.c
+++ b/mettle/src/log.c
@@ -18,12 +18,13 @@
 
 #include "log.h"
 
-FILE *zlog_fout = NULL;
+static FILE *zlog_fout = NULL;
 
-char _zlog_buffer[LOG_BUFFER_SIZE][LOG_BUFFER_STR_MAX_LEN];
-int _zlog_buffer_size = 0;
+static char _zlog_buffer[LOG_BUFFER_SIZE][LOG_BUFFER_STR_MAX_LEN];
+static int _zlog_buffer_size = 0;
+int _zlog_level = 0;
 
-pthread_mutex_t _zlog_buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t _zlog_buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static inline void _zlog_buffer_lock()
 {
@@ -181,7 +182,7 @@ void zlog(char *filename, int line, char const *fmt, ...)
 /*
  * hex dump from http://sws.dett.de/mini/hexdump-c/
  */
-void zlog_hex(char *filename, int line, const void *buf, size_t len)
+void zlog_info_hex(char *filename, int line, const void *buf, size_t len)
 {
 	const unsigned char *p = buf;
 	unsigned char c;

--- a/mettle/src/log.h
+++ b/mettle/src/log.h
@@ -27,14 +27,22 @@
  */
 #define LOG_BUFFER_FLUSH_SIZE (0.8 * LOG_BUFFER_SIZE)
 
+extern int _zlog_level;
+static inline void
+log_set_level(int level)
+{
+	_zlog_level = level;
+}
+
 /*
  * Public API
  */
 #ifdef LOG_DISABLE_LOG
 
-#define log_debug(format, ...)
 #define log_error(format, ...)
 #define log_info(format, ...)
+#define log_info_hex(buf, len)
+#define log_debug(format, ...)
 
 #define log_hex(buf, len)
 #define log_init(log_file)
@@ -45,14 +53,14 @@
 
 #else
 
-#define log_debug(format, ...) \
-	zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
 #define log_error(format, ...) \
-	zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
+	if (_zlog_level >= 0) zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
+#define log_debug(format, ...) \
+	if (_zlog_level >= 1) zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
 #define log_info(format, ...) \
-	zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
-#define log_hex(buf, len) \
-	zlog_hex(ZLOG_LOC, buf, len)
+	if (_zlog_level >= 2) zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
+#define log_info_hex(buf, len) \
+	if (_zlog_level >= 2) zlog_hex(ZLOG_LOC, buf, len)
 
 #define log_init(log_file) zlog_init(log_file)
 #define log_init_file(file_hdl) zlog_init_file(file_hdl)

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -32,7 +32,7 @@ static void start_logger(const char *out)
 {
 	FILE *l = stderr;
 	if (out) {
-	      FILE *f = fopen(out, "a");
+	      FILE *f = fopen(out, "w");
 	      if (f) l = f;
 	}
 	log_init_file(l);

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -54,6 +54,7 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 	const char *short_options = "hu:U:do:";
 	const char *out = NULL;
 	bool debug = false;
+	int log_level = 0;
 
 	while ((c = getopt_long(argc, argv, short_options, options, &index)) != -1) {
 		switch (c) {
@@ -65,6 +66,7 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 			break;
 		case 'd':
 			debug = true;
+			log_set_level(++log_level);
 			break;
 		case 'o':
 			out = optarg;

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -82,7 +82,7 @@ int start_heartbeat(struct mettle *m)
 
 int mettle_add_server_uri(struct mettle *m, const char *uri)
 {
-	return network_client_add_server(m->nc, uri);
+	return network_client_add_uri(m->nc, uri);
 }
 
 int mettle_add_tcp_sock(struct mettle *m, int fd)
@@ -223,7 +223,6 @@ struct mettle *mettle(void)
 	sigar_sys_info_get(m->sigar, &m->sysinfo);
 
 	network_client_set_connect_cb(m->nc, on_network_connect, m);
-
 	network_client_set_read_cb(m->nc, on_network_read, m);
 
 	m->td = tlv_dispatcher_new(on_tlv_response, m);

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -70,7 +70,7 @@ eio_done_poll(void)
 static void
 heartbeat_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 {
-	log_info("Heartbeat");
+	//log_info("Heartbeat");
 }
 
 int start_heartbeat(struct mettle *m)

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -70,7 +70,7 @@ eio_done_poll(void)
 static void
 heartbeat_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 {
-	//log_info("Heartbeat");
+	log_info("Heartbeat");
 }
 
 int start_heartbeat(struct mettle *m)
@@ -158,16 +158,18 @@ static void on_tlv_response(struct tlv_dispatcher *td, void *arg)
 	}
 }
 
-static void on_network_connect(struct network_client *nc, void *arg)
+static void on_network_event(struct bufferev *be, int event, void *arg)
 {
 	struct mettle *m = arg;
-	m->first_packet = true;
+	if (event & BEV_CONNECTED) {
+		m->first_packet = true;
+	}
 }
 
-static void on_network_read(struct network_client *nc, void *arg)
+static void on_network_read(struct bufferev *be, void *arg)
 {
 	struct mettle *m = arg;
-	struct buffer_queue *q = network_client_rx_queue(nc);
+	struct buffer_queue *q = bufferev_rx_queue(be);
 	struct tlv_packet *request;
 
 	if (m->first_packet) {
@@ -222,8 +224,7 @@ struct mettle *mettle(void)
 
 	sigar_sys_info_get(m->sigar, &m->sysinfo);
 
-	network_client_set_connect_cb(m->nc, on_network_connect, m);
-	network_client_set_read_cb(m->nc, on_network_read, m);
+	network_client_setcbs(m->nc, on_network_read, NULL, on_network_event, m);
 
 	m->td = tlv_dispatcher_new(on_tlv_response, m);
 	if (m->td == NULL) {

--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -25,20 +25,15 @@
 #endif
 #include <unistd.h>
 
+#include "bufferev.h"
 #include "buffer_queue.h"
 #include "log.h"
 #include "network_client.h"
 #include "util.h"
 
-enum network_client_proto {
-	network_client_proto_udp,
-	network_client_proto_tcp,
-	network_client_proto_tls,
-};
-
 struct network_client_server {
 	char *uri;
-	enum network_client_proto proto;
+	enum network_proto proto;
 	char *host;
 	char **services;
 	int num_services;
@@ -50,16 +45,11 @@ struct network_client {
 	struct network_client_server *servers;
 	int num_servers;
 
-	int sock;
-	struct ev_io data_ev;
-
 	int curr_server, curr_service;
 	uint64_t connect_time_s;
 
+	struct bufferev *be;
 	struct addrinfo *addrinfo;
-
-	struct buffer_queue *tx_queue;
-	struct buffer_queue *rx_queue;
 
 	enum {
 		network_client_closed,
@@ -68,44 +58,15 @@ struct network_client {
 		network_client_connected,
 	} state;
 
-	network_client_cb_t read_cb;
-	void *read_cb_arg;
 	network_client_cb_t connect_cb;
 	void *connect_cb_arg;
+	network_client_cb_t read_cb;
+	void *read_cb_arg;
+	network_client_cb_t error_cb;
+	void *error_cb_arg;
 	network_client_cb_t close_cb;
 	void *close_cb_arg;
 };
-
-struct {
-	enum network_client_proto proto;
-	const char *str;
-} proto_list[] = {
-	{network_client_proto_udp, "udp"},
-	{network_client_proto_tcp, "tcp"},
-	{network_client_proto_tcp, "tls"},
-};
-
-const char
-*proto_to_str(enum network_client_proto proto)
-{
-	for (int i = 0; i < COUNT_OF(proto_list); i++) {
-		if (proto_list[i].proto == proto) {
-			return proto_list[i].str;
-		}
-	}
-	return "unknown";
-}
-
-enum network_client_proto
-str_to_proto(const char *proto)
-{
-	for (int i = 0; i < COUNT_OF(proto_list); i++) {
-		if (!strcasecmp(proto_list[i].str, proto)) {
-			return proto_list[i].proto;
-		}
-	}
-	return network_client_proto_tcp;
-}
 
 void server_free(struct network_client_server *srv)
 {
@@ -145,7 +106,6 @@ int init_server(struct network_client_server *srv, const char *uri)
 	srv->uri = strdup(uri);
 
 	if (uri_tmp == NULL || srv->uri == NULL) {
-		log_error("fail");
 		goto out;
 	}
 
@@ -170,7 +130,7 @@ int init_server(struct network_client_server *srv, const char *uri)
 	}
 
 	srv->host = strdup(host);
-	srv->proto = str_to_proto(proto);
+	srv->proto = network_str_to_proto(proto);
 
 	if (services) {
 		char *services_tmp = strdup(services);
@@ -217,7 +177,7 @@ network_client_remove_servers(struct network_client *nc)
 }
 
 int
-network_client_add_server(struct network_client *nc, const char *uri)
+network_client_add_uri(struct network_client *nc, const char *uri)
 {
 	nc->servers = reallocarray(nc->servers, nc->num_servers + 1,
 			sizeof(struct network_client_server));
@@ -271,92 +231,43 @@ choose_next_server(struct network_client *nc)
 	return get_curr_server(nc);
 }
 
-/*
- * Callback management
- */
-
-void network_client_set_read_cb(struct network_client *nc,
-		network_client_cb_t cb, void *arg)
-{
-	nc->read_cb = cb;
-	nc->read_cb_arg = arg;
-}
-
-void network_client_set_connect_cb(struct network_client *nc,
-		network_client_cb_t cb, void *arg)
-{
-	nc->connect_cb = cb;
-	nc->connect_cb_arg = arg;
-}
-
-void network_client_set_close_cb(struct network_client *nc,
-		network_client_cb_t cb, void *arg)
-{
-	nc->close_cb = cb;
-	nc->close_cb_arg = arg;
-}
-
 struct buffer_queue * network_client_rx_queue(struct network_client *nc)
 {
-	return nc->rx_queue;
-}
-
-size_t network_client_bytes_available(struct network_client *nc)
-{
-	return buffer_queue_len(nc->rx_queue);
+	return bufferev_rx_queue(nc->be);
 }
 
 size_t network_client_peek(struct network_client *nc, void *buf, size_t buflen)
 {
-	return buffer_queue_copy(nc->rx_queue, buf, buflen);
+	return nc->be ? bufferev_peek(nc->be, buf, buflen) : 0;
 }
 
 size_t network_client_read(struct network_client *nc, void *buf, size_t buflen)
 {
-	return buffer_queue_remove(nc->rx_queue, buf, buflen);
+	return nc->be ? bufferev_read(nc->be, buf, buflen) : 0;
+}
+
+size_t network_client_bytes_available(struct network_client *nc)
+{
+	return nc->be ? bufferev_bytes_available(nc->be) : 0;
 }
 
 ssize_t network_client_write(struct network_client *nc, void *buf, size_t buflen)
 {
-	ssize_t off = 0, rc;
-	ssize_t sent_bytes = 0;
-	if (nc->state != network_client_connected) {
-		return -1;
-	}
-
-	switch (get_curr_server(nc)->proto) {
-	case network_client_proto_udp:
-		return send(nc->sock, buf, buflen, 0);
-	case network_client_proto_tcp:
-		do {
-			rc = send(nc->sock, buf + off, buflen - off, 0);
-			if (rc > 0) {
-				off += rc;
-				sent_bytes += rc;
-			}
-		} while (rc > 0 || (rc < 0 && (errno == EAGAIN || errno == EINTR)));
-		return sent_bytes;
-
-	case network_client_proto_tls:
-		return buffer_queue_add(nc->tx_queue, buf, buflen);
-	}
-
-	return -1;
+	return nc->be ? bufferev_write(nc->be, buf, buflen) : 0;
 }
 
 static void set_closed(struct network_client *nc)
 {
-	bool was_connected = nc->state == network_client_connected;
 	nc->state = network_client_closed;
+
 	if (nc->addrinfo) {
 		freeaddrinfo(nc->addrinfo);
 		nc->addrinfo = NULL;
 	}
 
-	buffer_queue_drain_all(nc->rx_queue);
-
-	if (was_connected && nc->close_cb) {
-		nc->close_cb(nc, nc->close_cb_arg);
+	if (nc->be) {
+		bufferev_free(nc->be);
+		nc->be = NULL;
 	}
 }
 
@@ -369,67 +280,92 @@ int network_client_close(struct network_client *nc)
 	return 0;
 }
 
+void network_client_set_read_cb(struct network_client *nc,
+	network_client_cb_t cb, void *arg)
+{
+	nc->read_cb = cb;
+	nc->read_cb_arg = arg;
+}
+
+void network_client_set_connect_cb(struct network_client *nc,
+	network_client_cb_t cb, void *arg)
+{
+	nc->connect_cb = cb;
+	nc->connect_cb_arg = arg;
+}
+
+void network_client_set_error_cb(struct network_client *nc,
+	network_client_cb_t cb, void *arg)
+{
+	nc->error_cb = cb;
+	nc->error_cb_arg = arg;
+}
+
+void network_client_set_close_cb(struct network_client *nc,
+	network_client_cb_t cb, void *arg)
+{
+	nc->close_cb = cb;
+	nc->close_cb_arg = arg;
+}
+
 void client_connected(struct network_client *nc)
 {
 	nc->state = network_client_connected;
 	struct network_client_server *srv = get_curr_server(nc);
-	log_info("connect to '%s://%s:%s'",
-			proto_to_str(srv->proto), srv->host, get_curr_service(nc));
+	log_info("connected to '%s://%s:%s'",
+		network_proto_to_str(srv->proto), srv->host, get_curr_service(nc));
+}
+
+static void on_connect(struct bufferev *be, void *arg)
+{
+	struct network_client *nc = arg;
+	client_connected(nc);
 	if (nc->connect_cb) {
 		nc->connect_cb(nc, nc->connect_cb_arg);
 	}
 }
 
-void enqueue_data(struct network_client *nc, void *data, size_t len)
+static void on_read(struct bufferev *be, void *arg)
 {
-	if (len) {
-		buffer_queue_add(nc->rx_queue, data, len);
-		if (nc->read_cb) {
-			nc->read_cb(nc, nc->read_cb_arg);
-		}
+	struct network_client *nc = arg;
+	if (nc->read_cb) {
+		nc->read_cb(nc, nc->read_cb_arg);
 	}
 }
 
-void on_read(struct ev_loop *loop, struct ev_io *w, int events)
+static void on_error(struct bufferev *be, void *arg)
 {
-	struct network_client *nc = w->data;
+	struct network_client *nc = arg;
 
-	ssize_t bytes_read = 0;
-	char buf[4096];
-	ssize_t rc;
-	while ((rc = recv(nc->sock, buf, sizeof(buf), 0)) > 0) {
-		bytes_read += rc;
-		enqueue_data(nc, buf, rc);
-	}
-
-	if (bytes_read <= 0) {
-		ev_io_stop(nc->loop, &nc->data_ev);
-		set_closed(nc);
-	}
-}
-
-static void
-on_connect(struct ev_loop *loop, struct ev_io *w, int events)
-{
-	struct network_client *nc = w->data;
-	struct network_client_server *srv = get_curr_server(nc);
-	ev_io_stop(nc->loop, &nc->data_ev);
-
-	int status;
-	socklen_t len = sizeof(status);
-	getsockopt(nc->sock, SOL_SOCKET, SO_ERROR, &status, &len);
-	if (status != 0) {
+	if (nc->state == network_client_connecting) {
+		struct network_client_server *srv = get_curr_server(nc);
 		log_info("failed to connect to '%s://%s:%s'",
-				proto_to_str(srv->proto), srv->host, get_curr_service(nc));
+				network_proto_to_str(srv->proto), srv->host, get_curr_service(nc));
 		set_closed(nc);
-		return;
 	}
 
-	client_connected(nc);
+	if (nc->error_cb) {
+		nc->error_cb(nc, nc->error_cb_arg);
+	}
+}
 
-	ev_io_init(&nc->data_ev, on_read, nc->sock, EV_READ);
-	nc->data_ev.data = nc;
-	ev_io_start(nc->loop, &nc->data_ev);
+static void on_close(struct bufferev *be, void *arg)
+{
+	struct network_client *nc = arg;
+	set_closed(nc);
+	if (nc->close_cb) {
+		nc->close_cb(nc, nc->close_cb_arg);
+	}
+}
+
+static void set_bufferev_cbs(struct network_client *nc)
+{
+	if (nc->be) {
+		bufferev_set_read_cb(nc->be, on_read, nc);
+		bufferev_set_connect_cb(nc->be, on_connect, nc);
+		bufferev_set_error_cb(nc->be, on_error, nc);
+		bufferev_set_close_cb(nc->be, on_close, nc);
+	}
 }
 
 static int
@@ -441,7 +377,7 @@ on_resolve(struct eio_req *req)
 
 	if (req->result != 0) {
 		log_info("could not resolve '%s://%s:%s': %s",
-			proto_to_str(srv->proto), srv->host, get_curr_service(nc),
+			network_proto_to_str(srv->proto), srv->host, get_curr_service(nc),
 			gai_strerror(req->result));
 		set_closed(nc);
 		return -1;
@@ -460,69 +396,20 @@ on_resolve(struct eio_req *req)
 
 		inet_ntop(p->ai_family, addr, ipstr, sizeof ipstr);
 
-		nc->sock = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
-		if (nc->sock >= 0) {
-			make_socket_nonblocking(nc->sock);
-			nc->state = network_client_connecting;
-			int rc = connect(nc->sock, p->ai_addr, p->ai_addrlen);
-			if (rc == 0 || errno == EINPROGRESS) {
-				log_info("connecting to %s: %s (%s)", srv->host, ipstr, strerror(errno));
-				ev_io_init(&nc->data_ev, on_connect, nc->sock, EV_WRITE);
-				nc->data_ev.data = nc;
-				ev_io_start(nc->loop, &nc->data_ev);
-			}
+		nc->state = network_client_connecting;
+
+		nc->be = bufferev_new(nc->loop);
+		set_bufferev_cbs(nc);
+
+		if (bufferev_connect_addrinfo(nc->be, p) == 0) {
 			return 0;
+		} else {
+			bufferev_free(nc->be);
+			nc->be = NULL;
 		}
 	}
 
 	set_closed(nc);
-	return 0;
-}
-
-static void
-resolve(struct eio_req *req)
-{
-	struct network_client *nc = req->data;
-	struct network_client_server *srv = get_curr_server(nc);
-	const char *service = get_curr_service(nc);
-
-	struct addrinfo hints = {
-		.ai_family = AF_UNSPEC,
-		.ai_flags = AI_CANONNAME,
-	};
-
-	if (srv->proto == network_client_proto_udp) {
-		hints.ai_socktype = SOCK_DGRAM;
-		hints.ai_protocol = IPPROTO_UDP;
-	} else {
-		hints.ai_socktype = SOCK_STREAM;
-		hints.ai_protocol = IPPROTO_TCP;
-	}
-
-	log_info("resolving %s://%s:%s",
-			proto_to_str(srv->proto), srv->host, service);
-
-	nc->state = network_client_resolving;
-	req->result = getaddrinfo(srv->host, service, &hints, &nc->addrinfo);
-}
-
-static void
-reconnect_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
-{
-	struct network_client *nc = (struct network_client *)w;
-
-	if (nc->state != network_client_closed || nc->num_servers == 0) {
-		return;
-	}
-
-	choose_next_server(nc);
-	eio_custom(resolve, 0, on_resolve, nc);
-}
-
-int network_client_start(struct network_client *nc)
-{
-	ev_timer_init(&nc->connect_timer, reconnect_cb, 0, 1.0);
-	ev_timer_start(nc->loop, &nc->connect_timer);
 	return 0;
 }
 
@@ -559,35 +446,78 @@ int network_client_add_tcp_sock(struct network_client *nc, int sock)
 		snprintf(service, sizeof(service), "%d", ntohs(s->sin6_port));
 	}
 
-	srv->proto = str_to_proto("tcp");
-
-	nc->sock = sock;
-	make_socket_nonblocking(nc->sock);
+	srv->proto = network_proto_tcp;
 
 	add_server_service(srv, service);
 
-	client_connected(nc);
-	ev_io_init(&nc->data_ev, on_read, nc->sock, EV_READ);
-	nc->data_ev.data = nc;
-	ev_io_start(nc->loop, &nc->data_ev);
+	if (nc->be == NULL) {
+		nc->be = bufferev_new(nc->loop);
+		set_bufferev_cbs(nc);
+		bufferev_connect_tcp_sock(nc->be, sock);
+		client_connected(nc);
+	}
+
 	return 0;
 }
 
-int network_client_stop(struct network_client *nc)
+static void
+resolve(struct eio_req *req)
 {
-	ev_timer_stop(nc->loop, &nc->connect_timer);
-	ev_io_stop(nc->loop, &nc->data_ev);
+	struct network_client *nc = req->data;
+	struct network_client_server *srv = get_curr_server(nc);
+	const char *service = get_curr_service(nc);
+
+	struct addrinfo hints = {
+		.ai_family = AF_UNSPEC,
+		.ai_flags = AI_CANONNAME,
+	};
+
+	if (srv->proto == network_proto_udp) {
+		hints.ai_socktype = SOCK_DGRAM;
+		hints.ai_protocol = IPPROTO_UDP;
+	} else {
+		hints.ai_socktype = SOCK_STREAM;
+		hints.ai_protocol = IPPROTO_TCP;
+	}
+
+	log_info("resolving %s://%s:%s",
+			network_proto_to_str(srv->proto), srv->host, service);
+
+	nc->state = network_client_resolving;
+	req->result = getaddrinfo(srv->host, service, &hints, &nc->addrinfo);
+}
+
+static void
+reconnect_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
+{
+	struct network_client *nc = (struct network_client *)w;
+
+	if (nc->state != network_client_closed || nc->num_servers == 0) {
+		return;
+	}
+
+	choose_next_server(nc);
+	eio_custom(resolve, 0, on_resolve, nc);
+}
+
+int network_client_start(struct network_client *nc)
+{
+	ev_timer_init(&nc->connect_timer, reconnect_cb, 0, 1.0);
+	ev_timer_start(nc->loop, &nc->connect_timer);
 	return 0;
 }
+
 
 void network_client_free(struct network_client *nc)
 {
 	if (nc) {
-		network_client_stop(nc);
+		if (nc->be) {
+			bufferev_free(nc->be);
+			nc->be = NULL;
+		}
+		ev_timer_stop(nc->loop, &nc->connect_timer);
 		network_client_close(nc);
 		network_client_remove_servers(nc);
-		buffer_queue_free(nc->rx_queue);
-		buffer_queue_free(nc->tx_queue);
 		free(nc);
 	}
 }
@@ -595,30 +525,9 @@ void network_client_free(struct network_client *nc)
 struct network_client * network_client_new(struct ev_loop *loop)
 {
 	struct network_client *nc = calloc(1, sizeof(*nc));
-	if (!nc) {
-		return NULL;
+	if (nc) {
+		nc->loop = loop;
+		nc->state = network_client_closed;
 	}
-
-	nc->rx_queue = buffer_queue_new();
-	if (nc->rx_queue == NULL) {
-		goto err;
-	}
-
-	nc->tx_queue = buffer_queue_new();
-	if (nc->tx_queue == NULL) {
-		goto err;
-	}
-
-	nc->loop = loop;
-
-	/*
-	 * initialize the connection timer
-	 */
-	nc->state = network_client_closed;
-
 	return nc;
-
-err:
-	network_client_free(nc);
-	return NULL;
 }

--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -408,7 +408,7 @@ on_resolve(struct eio_req *req)
 		nc->be = bufferev_new(nc->loop);
 		set_bufferev_cbs(nc);
 
-		if (bufferev_connect_addrinfo(nc->be, p) == 0) {
+		if (bufferev_connect_addrinfo(nc->be, p, 1.0) == 0) {
 			return 0;
 		} else {
 			bufferev_free(nc->be);

--- a/mettle/src/network_client.h
+++ b/mettle/src/network_client.h
@@ -33,6 +33,8 @@ void network_client_set_error_cb(struct network_client *nc,
 void network_client_set_close_cb(struct network_client *nc,
 	network_client_cb_t cb, void *arg);
 
+void network_client_set_retries(struct network_client *nc, int retries);
+
 struct buffer_queue * network_client_rx_queue(struct network_client *nc);
 
 size_t network_client_peek(struct network_client *nc, void *buf, size_t buflen);

--- a/mettle/src/network_client.h
+++ b/mettle/src/network_client.h
@@ -15,6 +15,8 @@ struct network_client;
 
 struct network_client * network_client_new(struct ev_loop *loop);
 
+void network_client_set_src(struct network_client *nc, const char *addr, uint16_t port);
+
 int network_client_add_uri(struct network_client *nc, const char *uri);
 
 int network_client_add_tcp_sock(struct network_client *nc, int sock);

--- a/mettle/src/network_client.h
+++ b/mettle/src/network_client.h
@@ -7,6 +7,8 @@
 #ifndef _NETWORK_CLIENT_H_
 #define _NETWORK_CLIENT_H_
 
+#include "bufferev.h"
+
 struct buffer_queue;
 
 struct network_client;
@@ -19,29 +21,15 @@ int network_client_add_tcp_sock(struct network_client *nc, int sock);
 
 int network_client_start(struct network_client *nc);
 
-typedef void (*network_client_cb_t)(struct network_client *nc, void *arg);
-
-void network_client_set_read_cb(struct network_client *nc,
-	network_client_cb_t cb, void *arg);
-
-void network_client_set_connect_cb(struct network_client *nc,
-	network_client_cb_t cb, void *arg);
-
-void network_client_set_error_cb(struct network_client *nc,
-	network_client_cb_t cb, void *arg);
-
-void network_client_set_close_cb(struct network_client *nc,
-	network_client_cb_t cb, void *arg);
+void network_client_setcbs(struct network_client *be,
+	bufferev_data_cb read_cb,
+	bufferev_data_cb write_cb,
+	bufferev_event_cb event_cb,
+	void *cb_arg);
 
 void network_client_set_retries(struct network_client *nc, int retries);
 
-struct buffer_queue * network_client_rx_queue(struct network_client *nc);
-
-size_t network_client_peek(struct network_client *nc, void *buf, size_t buflen);
-
-size_t network_client_read(struct network_client *nc, void *buf, size_t buflen);
-
-size_t network_client_bytes_available(struct network_client *nc);
+ssize_t network_client_read(struct network_client *nc, void *buf, size_t buflen);
 
 ssize_t network_client_write(struct network_client *nc, void *buf, size_t buflen);
 

--- a/mettle/src/network_client.h
+++ b/mettle/src/network_client.h
@@ -7,15 +7,13 @@
 #ifndef _NETWORK_CLIENT_H_
 #define _NETWORK_CLIENT_H_
 
-#include <ev.h>
-
-#include "buffer_queue.h"
+struct buffer_queue;
 
 struct network_client;
 
 struct network_client * network_client_new(struct ev_loop *loop);
 
-int network_client_add_server(struct network_client *nc, const char *uri);
+int network_client_add_uri(struct network_client *nc, const char *uri);
 
 int network_client_add_tcp_sock(struct network_client *nc, int sock);
 
@@ -24,13 +22,16 @@ int network_client_start(struct network_client *nc);
 typedef void (*network_client_cb_t)(struct network_client *nc, void *arg);
 
 void network_client_set_read_cb(struct network_client *nc,
-		network_client_cb_t cb, void *arg);
+	network_client_cb_t cb, void *arg);
 
 void network_client_set_connect_cb(struct network_client *nc,
-		network_client_cb_t cb, void *arg);
+	network_client_cb_t cb, void *arg);
+
+void network_client_set_error_cb(struct network_client *nc,
+	network_client_cb_t cb, void *arg);
 
 void network_client_set_close_cb(struct network_client *nc,
-		network_client_cb_t cb, void *arg);
+	network_client_cb_t cb, void *arg);
 
 struct buffer_queue * network_client_rx_queue(struct network_client *nc);
 

--- a/mettle/src/network_server.c
+++ b/mettle/src/network_server.c
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Rapid7
+ * @file network_server.h
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <ev.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#endif
+
+#include "bufferev.h"
+#include "log.h"
+#include "network_server.h"
+#include "util.h"
+
+struct network_server {
+	struct ev_loop *loop;
+	int listener;
+	struct ev_io connect_event;
+	struct sockaddr_in6 sin;
+};
+
+void accept_cb(struct ev_loop *loop, struct ev_io *watcher, int revents)
+{
+	log_debug("got a connection");
+}
+
+struct network_server * network_server_new(struct ev_loop *loop,
+		const char *host, uint16_t port,
+		void (* connect_cb)(struct bufferev *be, void *arg),
+		void (* read_cb)(struct bufferev *be, void *arg),
+		void (* close_cb)(struct network_server *ne))
+{
+	struct network_server *ns = calloc(1, sizeof(*ns));
+	if (ns == NULL) {
+		return NULL;
+	}
+
+	ns->sin.sin6_family = AF_INET6;
+	ns->sin.sin6_port = htons((uint16_t)port);
+
+	if (host == NULL) {
+		ns->sin.sin6_addr = in6addr_any;
+	} else {
+		// TODO bind to the specified host instead
+		ns->sin.sin6_addr = in6addr_any;
+	}
+
+	ns->listener = socket(AF_INET6, SOCK_STREAM, 0);
+	if (ns->listener == -1) {
+		goto err;
+	}
+	make_socket_nonblocking(ns->listener);
+
+	/*
+	 * SO_REUSEADDR means something different in windows
+	 */
+#ifndef _WIN32
+	int yes = 1;
+	setsockopt(ns->listener, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+#endif
+
+	/*
+	 * Override system default and allow socket to accept IPv4 and IPv6
+	 */
+#ifdef IPV6_V6ONLY
+	int no = 0;
+	setsockopt(ns->listener, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&no, sizeof(no));
+#endif
+
+	if (bind(ns->listener, (struct sockaddr *)&ns->sin, sizeof(ns->sin)) == -1) {
+		goto err;
+	}
+
+	if (listen(ns->listener, 16) == -1) {
+		goto err;
+	}
+
+	ev_io_init(&ns->connect_event, accept_cb, ns->listener, EV_READ);
+	ev_io_start(loop, &ns->connect_event);
+
+	return ns;
+err:
+	network_server_free(ns);
+	return NULL;
+}
+
+int network_server_start(struct network_server *ns);
+
+void network_server_free(struct network_server *ns)
+{
+	if (ns) {
+		if (ns->listener) {
+			close(ns->listener);
+		}
+		free(ns);
+	}
+}
+
+
+

--- a/mettle/src/network_server.h
+++ b/mettle/src/network_server.h
@@ -13,13 +13,18 @@
 struct network_server;
 
 struct network_server * network_server_new(struct ev_loop *loop,
-		const char *host, uint16_t port,
-		void (* connect_cb)(struct bufferev *be, void *arg),
-		void (* read_cb)(struct bufferev *be, void *arg),
-		void (* close_cb)(struct network_server *ne));
+		const char *host, uint16_t port);
 
-int network_server_start(struct network_server *ns);
+void network_server_setcbs(struct network_server *be,
+	bufferev_data_cb read_cb,
+	bufferev_data_cb write_cb,
+	bufferev_event_cb event_cb,
+	void *cb_arg);
 
 void network_server_free(struct network_server *ns);
+
+const char *network_server_get_host(struct network_server *ns);
+
+uint16_t network_server_get_port(struct network_server *ns);
 
 #endif

--- a/mettle/src/network_server.h
+++ b/mettle/src/network_server.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Rapid7
+ * @file network_server.h
+ */
+
+#ifndef _NETWORK_SERVER_H_
+#define _NETWORK_SERVER_H_
+
+#include <ev.h>
+
+#include "buffer_queue.h"
+
+struct network_server;
+
+struct network_server * network_server_new(struct ev_loop *loop);
+
+int network_server_start(struct network_server *nc);
+
+void network_server_free(struct network_server *nc);
+
+#endif

--- a/mettle/src/network_server.h
+++ b/mettle/src/network_server.h
@@ -8,14 +8,18 @@
 
 #include <ev.h>
 
-#include "buffer_queue.h"
+#include "bufferev.h"
 
 struct network_server;
 
-struct network_server * network_server_new(struct ev_loop *loop);
+struct network_server * network_server_new(struct ev_loop *loop,
+		const char *host, uint16_t port,
+		void (* connect_cb)(struct bufferev *be, void *arg),
+		void (* read_cb)(struct bufferev *be, void *arg),
+		void (* close_cb)(struct network_server *ne));
 
-int network_server_start(struct network_server *nc);
+int network_server_start(struct network_server *ns);
 
-void network_server_free(struct network_server *nc);
+void network_server_free(struct network_server *ns);
 
 #endif

--- a/mettle/src/process.c
+++ b/mettle/src/process.c
@@ -370,6 +370,19 @@ int process_kill(struct process* process)
 	return -1;
 }
 
+struct process * process_by_pid(struct procmgr *mgr, pid_t pid)
+{
+	struct process *p;
+	HASH_FIND_INT(mgr->processes, &pid, p);
+	return p;
+}
+
+int process_kill_by_pid(struct procmgr *mgr, pid_t pid)
+{
+	struct process *p = process_by_pid(mgr, pid);
+	return process_kill(p);
+}
+
 ssize_t process_read(struct process *process, void *buf, size_t buf_len)
 {
 	if (process == NULL) {

--- a/mettle/src/process.h
+++ b/mettle/src/process.h
@@ -51,6 +51,16 @@ ssize_t process_read(struct process *p, void *buf, size_t nbyte);
 int process_kill(struct process* process);
 
 /*
+ * Returns the managed process for a given PID
+ */
+struct process * process_by_pid(struct procmgr *mgr, pid_t pid);
+
+/*
+ * Kill the managed process for a given PID
+ */
+int process_kill_by_pid(struct procmgr *mgr, pid_t pid);
+
+/*
  * Returns the PID of the given process
  */
 pid_t process_get_pid(struct process *p);

--- a/mettle/src/stdapi/fs/file.c
+++ b/mettle/src/stdapi/fs/file.c
@@ -220,7 +220,6 @@ struct tlv_packet *fs_file_move(struct tlv_handler_ctx *ctx)
 		return tlv_packet_response_result(ctx, EINVAL);
 	}
 
-	struct mettle *m = ctx->arg;
 	eio_rename(src, dst, 0, fs_cb, ctx);
 	return NULL;
 }

--- a/mettle/src/stdapi/net/channel.c
+++ b/mettle/src/stdapi/net/channel.c
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2016 Rapid7
+ * @brief Network Channel API
+ * @file channel.c
+ */
+
+#include <mettle.h>
+
+#include "channel.h"
+#include "log.h"
+#include "network_client.h"
+#include "tlv.h"
+#include "util.h"
+
+/*
+ * Handlers registered with the network client to send data to the channel manager
+ */
+static void network_channel_close_cb(struct network_client *nc, void *arg)
+{
+	struct channel *c = arg;
+	channel_set_ctx(c, NULL);
+}
+
+static void network_channel_read_cb(struct network_client *nc, void *arg)
+{
+	struct channel *c = arg;
+	size_t len = network_client_bytes_available(nc);
+	void *buf = malloc(len);
+	log_debug("got %zu bytes", len);
+	if (buf) {
+		network_client_read(nc, buf, len);
+		channel_enqueue(c, buf, len);
+		free(buf);
+	}
+}
+
+static int _network_client_new(struct tlv_handler_ctx *ctx, struct channel *c, const char *proto)
+{
+	const char *src_host, *dst_host;
+	uint32_t src_port = -1, dst_port = -1;
+	struct mettle *m = ctx->arg;
+	struct network_client *nc = NULL;
+
+	dst_host = tlv_packet_get_str(ctx->req, TLV_TYPE_PEER_HOST);
+	src_host = tlv_packet_get_str(ctx->req, TLV_TYPE_LOCAL_HOST);
+
+	tlv_packet_get_u32(ctx->req, TLV_TYPE_PEER_PORT, &dst_port);
+	tlv_packet_get_u32(ctx->req, TLV_TYPE_LOCAL_HOST, &src_port);
+
+	if (dst_host == NULL || dst_port == -1) {
+		log_debug("dst_host %s, dst_port %u", dst_host, dst_port);
+		goto err;
+	}
+
+	if (src_host && src_port) {
+		log_debug("src_host %s, src_port %u", src_host, src_port);
+	}
+
+	nc = network_client_new(mettle_get_loop(m));
+	if (nc == NULL) {
+		log_debug("could not allocate network client");
+		goto err;
+	}
+
+	char *uri = NULL;
+	if (asprintf(&uri, "%s://%s:%u", proto, dst_host, dst_port) == -1) {
+		goto err;
+	}
+
+	if (network_client_add_server(nc, uri) == -1) {
+		log_debug("could not add server for uri %s", uri);
+		goto err;
+	}
+
+	free(uri);
+
+	channel_set_ctx(c, nc);
+	channel_set_interactive(c, true);
+	network_client_set_read_cb(nc, network_channel_read_cb, c);
+	network_client_set_close_cb(nc, network_channel_close_cb, c);
+	network_client_start(nc);
+
+	return 0;
+
+err:
+	if (nc) {
+		network_client_free(nc);
+	}
+	return -1;
+
+}
+
+static int tcp_client_new(struct tlv_handler_ctx *ctx, struct channel *c)
+{
+	return _network_client_new(ctx, c, "tcp");
+}
+
+ssize_t tcp_client_read(struct channel *c, void *buf, size_t len)
+{
+	struct network_client *nc = channel_get_ctx(c);
+	return network_client_read(nc, buf, len);
+}
+
+ssize_t tcp_client_write(struct channel *c, void *buf, size_t len)
+{
+	struct network_client *nc = channel_get_ctx(c);
+	return network_client_write(nc, buf, len);
+}
+
+int tcp_client_free(struct channel *c)
+{
+	struct network_client *nc = channel_get_ctx(c);
+	if (nc) {
+		network_client_free(nc);
+		channel_set_ctx(c, NULL);
+	}
+	return 0;
+}
+
+static struct tlv_packet *tcp_shutdown(struct tlv_handler_ctx *ctx)
+{
+	struct channel *c = tlv_handler_ctx_channel_by_id(ctx);
+	if (c == NULL) {
+		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
+	}
+
+	uint32_t how = 0;
+	tlv_packet_get_u32(ctx->req, TLV_TYPE_SHUTDOWN_HOW, &how);
+
+	const char *reasons[] = {"reads", "writes", "reads and writes", "unknown reasons"};
+	how = TYPESAFE_MIN(3, how);
+
+	log_info("shutting down connection for %s", reasons[how]);
+
+	/*
+	tcp_client_free(c);
+	channel_free(c);
+	*/
+
+	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
+static int udp_client_new(struct tlv_handler_ctx *ctx, struct channel *c)
+{
+	return _network_client_new(ctx, c, "udp");
+}
+
+ssize_t udp_client_read(struct channel *c, void *buf, size_t len)
+{
+	struct network_client *nc = channel_get_ctx(c);
+	return network_client_read(nc, buf, len);
+}
+
+ssize_t udp_client_write(struct channel *c, void *buf, size_t len)
+{
+	struct network_client *nc = channel_get_ctx(c);
+	return network_client_write(nc, buf, len);
+}
+
+int udp_client_free(struct channel *c)
+{
+	struct network_client *nc = channel_get_ctx(c);
+	network_client_free(nc);
+	return 0;
+}
+
+void net_channel_register_handlers(struct mettle *m)
+{
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+	struct channelmgr *cm = mettle_get_channelmgr(m);
+
+	struct channel_callbacks tcp_client_cbs = {
+		.new_cb = tcp_client_new,
+		.read_cb = tcp_client_read,
+		.write_cb = tcp_client_write,
+		.free_cb = tcp_client_free,
+	};
+	channelmgr_add_channel_type(cm, "stdapi_net_tcp_client", &tcp_client_cbs);
+	tlv_dispatcher_add_handler(td, "stdapi_net_socket_tcp_shutdown", tcp_shutdown, m);
+
+	struct channel_callbacks udp_client_cbs = {
+		.new_cb = udp_client_new,
+		.read_cb = udp_client_read,
+		.write_cb = udp_client_write,
+		.free_cb = udp_client_free,
+	};
+	channelmgr_add_channel_type(cm, "stdapi_net_udp_client", &udp_client_cbs);
+}

--- a/mettle/src/stdapi/net/channel.c
+++ b/mettle/src/stdapi/net/channel.c
@@ -67,7 +67,7 @@ static int _network_client_new(struct tlv_handler_ctx *ctx, struct channel *c, c
 		goto err;
 	}
 
-	if (network_client_add_server(nc, uri) == -1) {
+	if (network_client_add_uri(nc, uri) == -1) {
 		log_debug("could not add server for uri %s", uri);
 		goto err;
 	}

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -50,6 +50,7 @@ static void network_channel_connect_cb(struct network_client *nc, void *arg)
 	struct tlv_handler_ctx *ctx = arg;
 	struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 	tlv_dispatcher_enqueue_response(ctx->td, p);
+	channel_opened(ctx->channel);
 	tlv_handler_ctx_free(ctx);
 }
 

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -26,7 +26,6 @@ static void network_channel_read_cb(struct network_client *nc, void *arg)
 	struct channel *c = arg;
 	size_t len = network_client_bytes_available(nc);
 	void *buf = malloc(len);
-	log_debug("got %zu bytes", len);
 	if (buf) {
 		network_client_read(nc, buf, len);
 		channel_enqueue(c, buf, len);
@@ -95,19 +94,19 @@ static int tcp_client_new(struct tlv_handler_ctx *ctx, struct channel *c)
 	return _network_client_new(ctx, c, "tcp");
 }
 
-ssize_t tcp_client_read(struct channel *c, void *buf, size_t len)
+static ssize_t tcp_client_read(struct channel *c, void *buf, size_t len)
 {
 	struct network_client *nc = channel_get_ctx(c);
 	return network_client_read(nc, buf, len);
 }
 
-ssize_t tcp_client_write(struct channel *c, void *buf, size_t len)
+static ssize_t tcp_client_write(struct channel *c, void *buf, size_t len)
 {
 	struct network_client *nc = channel_get_ctx(c);
 	return network_client_write(nc, buf, len);
 }
 
-int tcp_client_free(struct channel *c)
+static int tcp_client_free(struct channel *c)
 {
 	struct network_client *nc = channel_get_ctx(c);
 	if (nc) {
@@ -132,11 +131,6 @@ static struct tlv_packet *tcp_shutdown(struct tlv_handler_ctx *ctx)
 
 	log_info("shutting down connection for %s", reasons[how]);
 
-	/*
-	tcp_client_free(c);
-	channel_free(c);
-	*/
-
 	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 }
 
@@ -145,26 +139,26 @@ static int udp_client_new(struct tlv_handler_ctx *ctx, struct channel *c)
 	return _network_client_new(ctx, c, "udp");
 }
 
-ssize_t udp_client_read(struct channel *c, void *buf, size_t len)
+static ssize_t udp_client_read(struct channel *c, void *buf, size_t len)
 {
 	struct network_client *nc = channel_get_ctx(c);
 	return network_client_read(nc, buf, len);
 }
 
-ssize_t udp_client_write(struct channel *c, void *buf, size_t len)
+static ssize_t udp_client_write(struct channel *c, void *buf, size_t len)
 {
 	struct network_client *nc = channel_get_ctx(c);
 	return network_client_write(nc, buf, len);
 }
 
-int udp_client_free(struct channel *c)
+static int udp_client_free(struct channel *c)
 {
 	struct network_client *nc = channel_get_ctx(c);
 	network_client_free(nc);
 	return 0;
 }
 
-void net_channel_register_handlers(struct mettle *m)
+void net_client_register_handlers(struct mettle *m)
 {
 	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
 	struct channelmgr *cm = mettle_get_channelmgr(m);

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -37,6 +37,8 @@ static void network_channel_read_cb(struct network_client *nc, void *arg)
 static void network_channel_error_cb(struct network_client *nc, void *arg)
 {
 	struct tlv_handler_ctx *ctx = arg;
+	log_info("sending failure result for request %s", ctx->id);
+	ctx->channel_id = 0;
 	struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	tlv_dispatcher_enqueue_response(ctx->td, p);
 	channel_shutdown(ctx->channel);

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -115,14 +115,14 @@ _network_client_new(struct tlv_handler_ctx *ctx, struct channel *c, const char *
 	const char *src_host, *dst_host;
 	uint32_t src_port = -1, dst_port = -1;
 	struct mettle *m = ctx->arg;
+	uint32_t retries = 0;
 
 	dst_host = tlv_packet_get_str(ctx->req, TLV_TYPE_PEER_HOST);
-	src_host = tlv_packet_get_str(ctx->req, TLV_TYPE_LOCAL_HOST);
-
 	tlv_packet_get_u32(ctx->req, TLV_TYPE_PEER_PORT, &dst_port);
+
+	src_host = tlv_packet_get_str(ctx->req, TLV_TYPE_LOCAL_HOST);
 	tlv_packet_get_u32(ctx->req, TLV_TYPE_LOCAL_HOST, &src_port);
 
-	uint32_t retries = 0;
 	tlv_packet_get_u32(ctx->req, TLV_TYPE_CONNECT_RETRIES, &retries);
 
 	if (dst_host == NULL || dst_port == -1) {

--- a/mettle/src/stdapi/net/config.c
+++ b/mettle/src/stdapi/net/config.c
@@ -95,9 +95,16 @@ static bool is_link_local_route(const struct addr *a)
 		a->addr_ip6.data[1] == 0x80;
 }
 
+static bool is_autoconf_route(const struct addr *a, uint32_t metric)
+{
+	return a->addr_type == ADDR_TYPE_IP6 && metric == 0;
+}
+
 static int add_route_info(const struct route_entry *entry, void *arg)
 {
-	if (entry->metric > 0 && entry->metric < 256 && !is_link_local_route(&entry->route_dst)) {
+	if (entry->metric < 256 &&
+			!is_autoconf_route(&entry->route_dst, entry->metric) &&
+			!is_link_local_route(&entry->route_dst)) {
 		struct tlv_packet **parent = arg;
 		struct tlv_packet *p = tlv_packet_new(TLV_TYPE_NETWORK_ROUTE, 0);
 		p = tlv_packet_add_addr(p, TLV_TYPE_SUBNET, TLV_TYPE_NETMASK, 0, &entry->route_dst);

--- a/mettle/src/stdapi/net/config.c
+++ b/mettle/src/stdapi/net/config.c
@@ -242,24 +242,31 @@ void get_netstat_async(struct eio_req *req)
 			remote_addr.addr_ip = connection->remote_address.addr.in;
 		} else if (connection->local_address.family == SIGAR_AF_INET6) {
 			local_addr.addr_type = remote_addr.addr_type = ADDR_TYPE_IP6;
-			memcpy(&local_addr.addr_ip6, &connection->local_address.addr.in6, sizeof(local_addr.addr_ip6));
-			memcpy(&remote_addr.addr_ip6, &connection->remote_address.addr.in6, sizeof(remote_addr.addr_ip6));
+			memcpy(&local_addr.addr_ip6, &connection->local_address.addr.in6,
+					sizeof(local_addr.addr_ip6));
+			memcpy(&remote_addr.addr_ip6, &connection->remote_address.addr.in6,
+					sizeof(remote_addr.addr_ip6));
 		}
+
 		if (local_addr.addr_type) {
 			p = tlv_packet_add_addr(p, TLV_TYPE_LOCAL_HOST_RAW, 0, &local_addr);
 			p = tlv_packet_add_addr(p, TLV_TYPE_PEER_HOST_RAW, 0, &remote_addr);
 		}
+
 		p = tlv_packet_add_u32(p, TLV_TYPE_LOCAL_PORT, connection->local_port);
 		p = tlv_packet_add_u32(p, TLV_TYPE_PEER_PORT, connection->remote_port);
+
 		if (connection->type == SIGAR_NETCONN_TCP) {
 			p = tlv_packet_add_str(p, TLV_TYPE_MAC_NAME, "tcp");
 			if (connection->state && connection->state < COUNT_OF(tcp_connection_states)) {
-				p = tlv_packet_add_str(p, TLV_TYPE_SUBNET_STRING, tcp_connection_states[connection->state]);
+				p = tlv_packet_add_str(p, TLV_TYPE_SUBNET_STRING,
+						tcp_connection_states[connection->state]);
 			}
 		} else if (connection->type == SIGAR_NETCONN_UDP) {
 			p = tlv_packet_add_str(p, TLV_TYPE_MAC_NAME, "udp");
 			if (connection->state && connection->state < COUNT_OF(udp_connection_states)) {
-				p = tlv_packet_add_str(p, TLV_TYPE_SUBNET_STRING, udp_connection_states[connection->state]);
+				p = tlv_packet_add_str(p, TLV_TYPE_SUBNET_STRING,
+						udp_connection_states[connection->state]);
 			}
 		}
 		p = tlv_packet_add_u32(p, TLV_TYPE_PID, connection->uid);

--- a/mettle/src/stdapi/net/resolve.c
+++ b/mettle/src/stdapi/net/resolve.c
@@ -53,7 +53,7 @@ void resolve_host_async(struct eio_req *req)
 						&((struct sockaddr_in6 *)(resolved_host->ai_addr))->sin6_addr, \
 						IP6_ADDR_LEN);
 			}
-			p = tlv_packet_add_addr(p, TLV_TYPE_IP, 0, &addr_host);
+			p = tlv_packet_add_addr(p, TLV_TYPE_IP, 0, 0, &addr_host);
 			p = tlv_packet_add_u32(p, TLV_TYPE_ADDR_TYPE, addr_type);
 
 			// XXX: C meterpreter has comment about this free possibliy causing segfaults on Linux

--- a/mettle/src/stdapi/net/server.c
+++ b/mettle/src/stdapi/net/server.c
@@ -12,15 +12,50 @@
 #include "tlv.h"
 #include "util.h"
 
-static struct tlv_packet *tcp_server_new(struct tlv_handler_ctx *ctx)
+static int tcp_server_new(struct tlv_handler_ctx *ctx, struct channel *c)
 {
-	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+	uint32_t port = 0;
+	struct mettle *m = ctx->arg;
+
+	const char *host = tlv_packet_get_str(ctx->req, TLV_TYPE_LOCAL_HOST);
+
+	if (tlv_packet_get_u32(ctx->req, TLV_TYPE_LOCAL_PORT, &port) == -1) {
+		log_error("no port specified");
+		return -1;
+	}
+
+	return 0;
+}
+
+static ssize_t tcp_server_read(struct channel *c, void *buf, size_t len)
+{
+	return 0;
+}
+
+static ssize_t tcp_server_write(struct channel *c, void *buf, size_t len)
+{
+	return 0;
+}
+
+static int tcp_server_free(struct channel *c)
+{
+	struct network_server *nc = channel_get_ctx(c);
+	if (nc) {
+		channel_set_ctx(c, NULL);
+	}
+	return 0;
 }
 
 void net_server_register_handlers(struct mettle *m)
 {
-	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+	struct channelmgr *cm = mettle_get_channelmgr(m);
 
-	tlv_dispatcher_add_handler(td, "stdapi_net_tcp_server", tcp_server_new, m);
+	struct channel_callbacks tcp_server_cbs = {
+		.new_cb = tcp_server_new,
+		.read_cb = tcp_server_read,
+		.write_cb = tcp_server_write,
+		.free_cb = tcp_server_free,
+	};
+	channelmgr_add_channel_type(cm, "stdapi_net_tcp_server", &tcp_server_cbs);
 }
 

--- a/mettle/src/stdapi/net/server.c
+++ b/mettle/src/stdapi/net/server.c
@@ -12,10 +12,100 @@
 #include "tlv.h"
 #include "util.h"
 
+struct network_server_channel
+{
+	struct tlv_dispatcher *td;
+	struct channel *channel;
+	struct network_server *ns;
+};
+
+struct tcp_server_conn
+{
+	struct channel *channel;
+	struct bufferev *be;
+};
+
+static void conn_read_cb(struct bufferev *be, void *arg)
+{
+	struct tcp_server_conn *conn = arg;
+	size_t len = bufferev_bytes_available(be);
+	void *buf = malloc(len);
+	if (buf) {
+		bufferev_read(be, buf, len);
+		channel_enqueue(conn->channel, buf, len);
+		free(buf);
+	}
+}
+
+static void conn_event_cb(struct bufferev *be, int event, void *arg)
+{
+	struct tcp_server_conn *conn = arg;
+
+	if (event & (BEV_EOF | BEV_ERROR)) {
+		channel_set_ctx(conn->channel, NULL);
+		channel_send_close_request(conn->channel);
+		free(conn);
+	}
+}
+
+static void open_tcp_channel(struct network_server_channel *nsc, struct bufferev *be)
+{
+	struct channelmgr *cm = channel_get_channelmgr(nsc->channel);
+	struct tcp_server_conn *conn = calloc(1, sizeof(*conn));
+	if (conn == NULL) {
+		return;
+	}
+
+	conn->be = be;
+	conn->channel = channelmgr_channel_new(cm, "tcp_server_conn");
+	if (conn->channel == NULL) {
+		return;
+	}
+
+	struct tlv_packet *p = tlv_packet_new(TLV_PACKET_TYPE_REQUEST, 128);
+	if (p == NULL) {
+		channel_free(conn->channel);
+		return;
+	}
+
+	p = tlv_packet_add_uuid(p, nsc->td);
+	p = tlv_packet_add_fmt(p, TLV_TYPE_METHOD, "tcp_channel_open");
+	p = tlv_packet_add_fmt(p, TLV_TYPE_REQUEST_ID,
+			"channel-req-%d", channel_get_id(conn->channel));
+	p = tlv_packet_add_u32(p, TLV_TYPE_CHANNEL_ID, channel_get_id(conn->channel));
+	p = tlv_packet_add_u32(p, TLV_TYPE_CHANNEL_PARENTID, channel_get_id(nsc->channel));
+
+	uint16_t local_port;
+	char *local_host = bufferev_get_local_addr(be, &local_port);
+	p = tlv_packet_add_str(p, TLV_TYPE_LOCAL_HOST, local_host);
+	p = tlv_packet_add_u32(p, TLV_TYPE_LOCAL_PORT, local_port);
+
+	uint16_t peer_port;
+	char *peer_host = bufferev_get_peer_addr(be, &peer_port);
+	p = tlv_packet_add_str(p, TLV_TYPE_PEER_HOST, peer_host);
+	p = tlv_packet_add_u32(p, TLV_TYPE_PEER_PORT, peer_port);
+
+	bufferev_setcbs(be, conn_read_cb, NULL, conn_event_cb, conn);
+	channel_set_ctx(conn->channel, conn);
+	channel_set_interactive(conn->channel, true);
+
+	tlv_dispatcher_enqueue_response(nsc->td, p);
+}
+
+static void tcp_server_event_cb(struct bufferev *be, int event, void *arg)
+{
+	struct network_server_channel *nsc = arg;
+
+	if (event & BEV_CONNECTED) {
+		open_tcp_channel(nsc, be);
+	}
+}
+
 static int tcp_server_new(struct tlv_handler_ctx *ctx, struct channel *c)
 {
 	uint32_t port = 0;
 	struct mettle *m = ctx->arg;
+	struct network_server_channel *nsc;
 
 	const char *host = tlv_packet_get_str(ctx->req, TLV_TYPE_LOCAL_HOST);
 
@@ -24,16 +114,25 @@ static int tcp_server_new(struct tlv_handler_ctx *ctx, struct channel *c)
 		return -1;
 	}
 
-	return 0;
-}
+	nsc = calloc(1, sizeof(*nsc));
+	if (nsc == NULL) {
+		return -1;
+	}
 
-static ssize_t tcp_server_read(struct channel *c, void *buf, size_t len)
-{
-	return 0;
-}
+	nsc->channel = c;
+	nsc->td = mettle_get_tlv_dispatcher(m);
 
-static ssize_t tcp_server_write(struct channel *c, void *buf, size_t len)
-{
+	nsc->ns = network_server_new(mettle_get_loop(m), host, port);
+	if (nsc->ns == NULL) {
+		log_info("failed to listen on %s:%d", host, port);
+		free(nsc);
+		return -1;
+	}
+
+	network_server_setcbs(nsc->ns, NULL, NULL, tcp_server_event_cb, nsc);
+	channel_set_ctx(c, nsc);
+	log_info("listening on %s:%d", host, port);
+
 	return 0;
 }
 
@@ -46,16 +145,45 @@ static int tcp_server_free(struct channel *c)
 	return 0;
 }
 
+static ssize_t tcp_conn_read(struct channel *c, void *buf, size_t len)
+{
+	struct tcp_server_conn *conn = channel_get_ctx(c);
+	return bufferev_read(conn->be, buf, len);
+}
+
+static ssize_t tcp_conn_write(struct channel *c, void *buf, size_t len)
+{
+	struct tcp_server_conn *conn = channel_get_ctx(c);
+	return bufferev_write(conn->be, buf, len);
+}
+
+static int tcp_conn_free(struct channel *c)
+{
+	struct tcp_server_conn *conn = channel_get_ctx(c);
+	if (conn) {
+		channel_set_ctx(c, NULL);
+		bufferev_free(conn->be);
+		free(conn);
+	}
+	return 0;
+}
+
 void net_server_register_handlers(struct mettle *m)
 {
 	struct channelmgr *cm = mettle_get_channelmgr(m);
 
 	struct channel_callbacks tcp_server_cbs = {
 		.new_cb = tcp_server_new,
-		.read_cb = tcp_server_read,
-		.write_cb = tcp_server_write,
 		.free_cb = tcp_server_free,
 	};
 	channelmgr_add_channel_type(cm, "stdapi_net_tcp_server", &tcp_server_cbs);
+
+	struct channel_callbacks tcp_conn_cbs = {
+		.read_cb = tcp_conn_read,
+		.write_cb = tcp_conn_write,
+		.free_cb = tcp_conn_free,
+	};
+	channelmgr_add_channel_type(cm, "tcp_server_conn", &tcp_conn_cbs);
+
 }
 

--- a/mettle/src/stdapi/net/server.c
+++ b/mettle/src/stdapi/net/server.c
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Rapid7
+ * @brief Network Channel API
+ * @file channel.c
+ */
+
+#include <mettle.h>
+
+#include "channel.h"
+#include "log.h"
+#include "network_server.h"
+#include "tlv.h"
+#include "util.h"
+
+static struct tlv_packet *tcp_server_new(struct tlv_handler_ctx *ctx)
+{
+	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
+void net_server_register_handlers(struct mettle *m)
+{
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+
+	tlv_dispatcher_add_handler(td, "stdapi_net_tcp_server", tcp_server_new, m);
+}
+

--- a/mettle/src/stdapi/stdapi.c
+++ b/mettle/src/stdapi/stdapi.c
@@ -6,8 +6,9 @@
 
 #include "mettle.h"
 #include "fs/file.c"
-#include "net/channel.c"
+#include "net/client.c"
 #include "net/config.c"
+#include "net/server.c"
 #include "net/resolve.c"
 #include "sys/config.c"
 #include "sys/process.c"
@@ -18,7 +19,8 @@ void tlv_register_stdapi(struct mettle *m)
 
 	file_register_handlers(m);
 
-	net_channel_register_handlers(m);
+	net_client_register_handlers(m);
+	net_server_register_handlers(m);
 	net_config_register_handlers(m);
 	net_resolve_register_handlers(m);
 

--- a/mettle/src/stdapi/stdapi.c
+++ b/mettle/src/stdapi/stdapi.c
@@ -6,6 +6,7 @@
 
 #include "mettle.h"
 #include "fs/file.c"
+#include "net/channel.c"
 #include "net/config.c"
 #include "net/resolve.c"
 #include "sys/config.c"
@@ -17,6 +18,7 @@ void tlv_register_stdapi(struct mettle *m)
 
 	file_register_handlers(m);
 
+	net_channel_register_handlers(m);
 	net_config_register_handlers(m);
 	net_resolve_register_handlers(m);
 

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -199,7 +199,7 @@ int sys_process_free(struct channel *c)
 static void process_channel_exit_cb(struct process *p, int exit_status, void *arg)
 {
 	struct channel *c = arg;
-	channel_set_ctx(c, NULL);
+	channel_send_close_request(c);
 }
 
 static void process_channel_read_cb(struct buffer_queue *queue, void *arg)

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -528,11 +528,11 @@ int tlv_dispatcher_process_request(struct tlv_dispatcher *td, struct tlv_packet 
 	struct tlv_packet *response = NULL;
 	struct tlv_handler *handler = find_handler(td, ctx->method);
 	if (handler == NULL) {
-		log_info("no handler found for method: '%s'", ctx->method);
+		log_error("no handler found for method: '%s'", ctx->method);
 		response = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 
 	} else {
-		log_debug("processing method: '%s' id: '%s'", ctx->method, ctx->id);
+		log_info("processing method: '%s' id: '%s'", ctx->method, ctx->id);
 		ctx->arg = handler->arg;
 		response = handler->cb(ctx);
 	}

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -339,14 +339,9 @@ struct tlv_packet * tlv_packet_response(struct tlv_handler_ctx *ctx)
 {
 	struct tlv_packet *p = tlv_packet_new(TLV_PACKET_TYPE_RESPONSE,
 			tlv_packet_len(ctx->req) + 32);
-	p = tlv_packet_add_str(p, TLV_TYPE_METHOD, ctx->method);
 
-	size_t uuid_len = 0;
-	struct tlv_dispatcher *td = ctx->td;
-	const char* uuid = tlv_dispatcher_get_uuid(td, &uuid_len);
-	if (uuid && uuid_len) {
-		p = tlv_packet_add_raw(p, TLV_TYPE_UUID, uuid, uuid_len);
-	}
+	p = tlv_packet_add_uuid(p, ctx->td);
+	p = tlv_packet_add_str(p, TLV_TYPE_METHOD, ctx->method);
 
 	if (ctx->channel_id) {
 		p = tlv_packet_add_u32(p, TLV_TYPE_CHANNEL_ID, ctx->channel_id);
@@ -386,6 +381,16 @@ struct tlv_dispatcher {
 	char *uuid;
 	size_t uuid_len;
 };
+
+struct tlv_packet *tlv_packet_add_uuid(struct tlv_packet *p, struct tlv_dispatcher *td)
+{
+	size_t uuid_len = 0;
+	const char* uuid = tlv_dispatcher_get_uuid(td, &uuid_len);
+	if (uuid && uuid_len) {
+		p = tlv_packet_add_raw(p, TLV_TYPE_UUID, uuid, uuid_len);
+	}
+	return p;
+}
 
 int tlv_dispatcher_enqueue_response(struct tlv_dispatcher *td, struct tlv_packet *p)
 {

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -82,7 +82,8 @@ struct tlv_packet * tlv_packet_add_bool(struct tlv_packet *p,
 		uint32_t type, bool val);
 
 struct tlv_packet * tlv_packet_add_addr(struct tlv_packet *p,
-	uint32_t addr_tlv, uint32_t mask_tlv, const struct addr *a);
+	uint32_t addr_tlv, uint32_t mask_tlv, uint32_t intf_index,
+	const struct addr *a);
 
 void tlv_packet_free(struct tlv_packet *p);
 

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -90,6 +90,8 @@ void tlv_packet_free(struct tlv_packet *p);
  * TLV Handler
  */
 struct channel;
+struct tlv_dispatcher;
+
 struct tlv_handler_ctx {
 	const char *method;
 	const char *id;
@@ -106,6 +108,8 @@ void tlv_handler_ctx_free(struct tlv_handler_ctx *ctx);
 
 struct tlv_packet * tlv_packet_add_result(struct tlv_packet *p, int rc);
 
+struct tlv_packet * tlv_packet_add_uuid(struct tlv_packet *p, struct tlv_dispatcher *td);
+
 struct tlv_packet * tlv_packet_response(struct tlv_handler_ctx *ctx);
 
 struct tlv_packet * tlv_packet_response_result(struct tlv_handler_ctx *ctx, int rc);
@@ -114,8 +118,6 @@ struct tlv_packet * tlv_packet_response_result(struct tlv_handler_ctx *ctx, int 
  * TLV Dispatcher
  */
 typedef void (*tlv_response_cb)(struct tlv_dispatcher *td, void *arg);
-
-struct tlv_dispatcher;
 
 struct tlv_dispatcher * tlv_dispatcher_new(tlv_response_cb cb, void *cb_arg);
 


### PR DESCRIPTION
This is incomplete but close to being finished. I thought I'd get it out as a PR early since a few folks have been asking for it, and I wanted to show how to hook it into an event loop.

Right now, I've mostly focused on client-side TCP, but since we already had the network_client functionality used for the transport connections, this reuses it. At first I just used it directly, but it made sense to pull out the network buffering abstraction for use on the server-side as well.

Update: tcp server-side support is not implemented as well.