### PR TITLE
Revert uuid encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The available platform triples are:
 * `mips-linux-muslsf`
 * `mipsel-linux-muslsf`
 * `mips64-linux-muslsf`
+* `s390x-linux-musl`
 
 Available config options are:
 * `:uri` - the uri to connect back to

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The available platform triples are:
 * `mips64-linux-muslsf`
 
 Available config options are:
-* `:url` - the url to connect back to
+* `:uri` - the uri to connect back to
 * `:uuid` - the UUID to identify the payload
 * `:debug` - to turn on debug messages
 * `:log_file` - the file to send debug messages to instead of `stderr`

--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -1,7 +1,5 @@
 # -*- coding:binary -*-
 
-require 'base64'
-
 unless defined? MetasploitPayloads::Mettle::VERSION
   require 'metasploit_payloads/mettle/version'
 end
@@ -40,21 +38,13 @@ module MetasploitPayloads
     def generate_argv
       cmd_line = 'mettle '
       @config.each do |opt, val|
-        cmd_line << "-#{short_opt(opt)} \"#{encode_val(opt, val)}\" "
+        cmd_line << "-#{short_opt(opt)} \"#{val}\" "
       end
       if cmd_line.length > 264
         fail RuntimeError, 'mettle argument list too big', caller
       end
 
       cmd_line + "\x00" * (264 - cmd_line.length)
-    end
-
-    def encode_val(opt, val)
-      if opt == :uuid
-        Base64::encode64(val.to_raw)
-      else
-        val
-      end
     end
 
     def short_opt(opt)


### PR DESCRIPTION
This removes dependency inversion introduced to encode UUIDs. The MSF side of this is rapid7/metasploit-framework#7681 . That PR needs to be updated with the mettle gem version that contains this fix.