### PR TITLE
Fix builds on PAX hardenned systems

### DIFF
--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -23,6 +23,9 @@ ELF2BIN=build/tools/elf2bin
 $(ELF2BIN): util/elf2bin.c
 	@mkdir -p build/tools
 	cc -g -o $@ $<
+	if [[ ! -z "$(which paxctl)" ]]; then
+		paxctl -cem build/tools/elf2bin
+	fi
 
 INSTALL=install
 export PATH:=$(ROOT)/build/tools/musl-cross/bin:$(PATH)


### PR DESCRIPTION
PAX flags on RWX memory protections for elf2bin's machinations,
resulting in build failures unless one manually sets the FS xattr
or PAX header flags on the binary.

This is the low road - check for presence of paxctl binary in the
PATH, use it to convert the ELF headers, and set "em" flags which
allow unsafe memory operations to be performed.
The high road would be to check sysctls and set FS XATTRs, but it
would add unecessary complexity as well as privilege requirements
generally undesirable for build enivironments (root builds == bad).

TPE and other restrictions commonly present in grsec environments
are not addressed here.