### PR TITLE
Add UDP network channel support

### DIFF
--- a/mettle/src/buffer_queue.h
+++ b/mettle/src/buffer_queue.h
@@ -29,6 +29,10 @@ size_t buffer_queue_drain(struct buffer_queue *q, size_t len);
 
 void buffer_queue_drain_all(struct buffer_queue *q);
 
+void * buffer_queue_peek_msg(struct buffer_queue *q, size_t *len);
+
+void * buffer_queue_remove_msg(struct buffer_queue *q, size_t *len);
+
 ssize_t buffer_queue_remove_all(struct buffer_queue *q, void **data);
 
 #endif

--- a/mettle/src/bufferev.h
+++ b/mettle/src/bufferev.h
@@ -7,6 +7,7 @@
 #define _BUFFEREV_H_
 
 #include <ev.h>
+#include <sys/types.h>
 
 #include "buffer_queue.h"
 
@@ -50,6 +51,19 @@ struct buffer_queue * bufferev_rx_queue(struct bufferev *be);
 size_t bufferev_peek(struct bufferev *be, void *buf, size_t buflen);
 
 size_t bufferev_read(struct bufferev *be, void *buf, size_t buflen);
+
+struct bufferev_udp_msg {
+	socklen_t src_len;
+	ssize_t buf_len;
+	struct sockaddr_storage src;
+	char buf[];
+};
+
+char * bufferev_get_udp_msg_peer_addr(struct bufferev_udp_msg *msg, uint16_t *port);
+
+void *bufferev_read_msg(struct bufferev *be, size_t *len);
+
+void *bufferev_peek_msg(struct bufferev *be, size_t *len);
 
 size_t bufferev_bytes_available(struct bufferev *be);
 

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -145,6 +145,15 @@ static int send_write_request(struct channel *c, void *buf, size_t buf_len)
 	return tlv_dispatcher_enqueue_response(c->cm->td, p);
 };
 
+int channel_enqueue_ex(struct channel *c, void *buf, size_t buf_len, struct tlv_packet *extra)
+{
+	struct tlv_packet *p = new_request(c, "write", buf_len);
+	p = tlv_packet_add_raw(p, TLV_TYPE_CHANNEL_DATA, buf, buf_len);
+	p = tlv_packet_add_u32(p, TLV_TYPE_LENGTH, buf_len);
+	p = tlv_packet_merge_child(p, extra);
+	return tlv_dispatcher_enqueue_response(c->cm->td, p);
+}
+
 int channel_enqueue(struct channel *c, void *buf, size_t buf_len)
 {
 	if (c->interactive) {

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -171,7 +171,9 @@ int channel_enqueue_buffer_queue(struct channel *c, struct buffer_queue *q)
 		return -1;
 	}
 
-	return channel_enqueue(c, buf, buf_len);
+	int rc = channel_enqueue(c, buf, buf_len);
+	free(buf);
+	return rc;
 }
 
 ssize_t channel_dequeue(struct channel *c, void *buf, size_t buf_len)

--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -66,6 +66,9 @@ int channel_send_close_request(struct channel *c);
 
 int channel_enqueue(struct channel *c, void *buf, size_t buf_len);
 
+int channel_enqueue_ex(struct channel *c, void *buf, size_t buf_len,
+		struct tlv_packet *extra);
+
 int channel_enqueue_buffer_queue(struct channel *c, struct buffer_queue *bq);
 
 ssize_t channel_dequeue(struct channel *c, void *buf, size_t buf_len);

--- a/mettle/src/log.c
+++ b/mettle/src/log.c
@@ -182,7 +182,7 @@ void zlog(char *filename, int line, char const *fmt, ...)
 /*
  * hex dump from http://sws.dett.de/mini/hexdump-c/
  */
-void zlog_info_hex(char *filename, int line, const void *buf, size_t len)
+void zlog_hex(char *filename, int line, const void *buf, size_t len)
 {
 	const unsigned char *p = buf;
 	unsigned char c;

--- a/mettle/src/log.h
+++ b/mettle/src/log.h
@@ -40,11 +40,12 @@ log_set_level(int level)
 #ifdef LOG_DISABLE_LOG
 
 #define log_error(format, ...)
+#define log_error_hex(buf, len)
 #define log_info(format, ...)
 #define log_info_hex(buf, len)
 #define log_debug(format, ...)
+#define log_debug_hex(buf, len)
 
-#define log_hex(buf, len)
 #define log_init(log_file)
 #define log_init_file(file_hdl)
 #define log_init_flush_thread
@@ -55,8 +56,12 @@ log_set_level(int level)
 
 #define log_error(format, ...) \
 	if (_zlog_level >= 0) zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
+#define log_error_hex(buf, len) \
+	if (_zlog_level >= 0) zlog_hex(ZLOG_LOC, buf, len)
 #define log_debug(format, ...) \
 	if (_zlog_level >= 1) zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
+#define log_debug_hex(buf, len) \
+	if (_zlog_level >= 1) zlog_hex(ZLOG_LOC, buf, len)
 #define log_info(format, ...) \
 	if (_zlog_level >= 2) zlog_time(ZLOG_LOC, format "\n", ##__VA_ARGS__)
 #define log_info_hex(buf, len) \

--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -497,7 +497,7 @@ resolve(struct eio_req *req)
 
 	if ((nc->src_addr || nc->src_port) && nc->src == NULL) {
 		char *port = NULL;
-		if (nc->src_port > 0 && nc->src_port <= UINT16_MAX) {
+		if (nc->src_port > 0) {
 			asprintf(&port, "%u", nc->src_port);
 		}
 		getaddrinfo(nc->src_addr, port, &hints, &nc->src);

--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -253,6 +253,11 @@ ssize_t network_client_read(struct network_client *nc, void *buf, size_t buflen)
 	return nc->be ? bufferev_read(nc->be, buf, buflen) : 0;
 }
 
+void * network_client_read_msg(struct network_client *nc, size_t *buflen)
+{
+	return nc->be ? bufferev_read_msg(nc->be, buflen) : NULL;
+}
+
 ssize_t network_client_write(struct network_client *nc, void *buf, size_t buflen)
 {
 	return nc->be ? bufferev_write(nc->be, buf, buflen) : 0;
@@ -294,7 +299,7 @@ client_connected(struct network_client *nc)
 {
 	nc->state = network_client_connected;
 	struct network_client_server *srv = get_curr_server(nc);
-	log_info("connected to '%s://%s:%s'",
+	log_info("connected to %s://%s:%s",
 		network_proto_to_str(srv->proto), srv->host, get_curr_service(nc));
 }
 
@@ -350,6 +355,7 @@ log_addrinfo(const char *msg, struct addrinfo *ai)
 {
 	char host[INET6_ADDRSTRLEN] = { 0 };
 	uint16_t port = 0;
+	const char *proto = ai->ai_protocol == IPPROTO_UDP ? "udp" : "tcp";
 	if (ai->ai_family == AF_INET) {
 		struct sockaddr_in *s = (struct sockaddr_in *)ai->ai_addr;
 		port = ntohs(s->sin_port);
@@ -359,7 +365,7 @@ log_addrinfo(const char *msg, struct addrinfo *ai)
 		port = ntohs(s->sin6_port);
 		inet_ntop(AF_INET6, &s->sin6_addr, host, INET6_ADDRSTRLEN);
 	}
-	log_info("%s %s:%d", msg, host, port);
+	log_info("%s %s://%s:%d", msg, proto, host, port);
 }
 
 static int
@@ -403,6 +409,7 @@ on_resolve(struct eio_req *req)
 		freeaddrinfo(nc->addrinfo);
 		nc->addrinfo = NULL;
 	}
+
 	if (failed) {
 		connection_failed(nc);
 	}

--- a/mettle/src/network_client.h
+++ b/mettle/src/network_client.h
@@ -33,6 +33,8 @@ void network_client_set_retries(struct network_client *nc, int retries);
 
 ssize_t network_client_read(struct network_client *nc, void *buf, size_t buflen);
 
+void * network_client_read_msg(struct network_client *nc, size_t *buflen);
+
 ssize_t network_client_write(struct network_client *nc, void *buf, size_t buflen);
 
 int network_client_close(struct network_client *nc);

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -33,13 +33,7 @@ tcp_client_channel_free(struct tcp_client_channel *nc)
 void tcp_client_channel_read_cb(struct bufferev *be, void *arg)
 {
 	struct tcp_client_channel *tcc = arg;
-	size_t len = bufferev_bytes_available(be);
-	void *buf = malloc(len);
-	if (buf) {
-		bufferev_read(be, buf, len);
-		channel_enqueue(tcc->channel, buf, len);
-		free(buf);
-	}
+	channel_enqueue_buffer_queue(tcc->channel, bufferev_rx_queue(be));
 }
 
 void tcp_client_channel_event_cb(struct bufferev *be, int event, void *arg)

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -193,9 +193,6 @@ void udp_client_channel_read_cb(struct bufferev *be, void *arg)
 			struct tlv_packet *p = tlv_packet_new(0, 32);
 			p = tlv_packet_add_str(p, TLV_TYPE_PEER_HOST, peer_host);
 			p = tlv_packet_add_u32(p, TLV_TYPE_PEER_PORT, peer_port);
-
-			log_debug("hmm: %s:%d", peer_host, peer_port);
-
 			channel_enqueue_ex(ucc->channel, msg->buf, msg->buf_len, p);
 		}
 		free(peer_host);

--- a/mettle/src/stdapi/net/server.c
+++ b/mettle/src/stdapi/net/server.c
@@ -28,13 +28,7 @@ struct tcp_server_conn
 static void conn_read_cb(struct bufferev *be, void *arg)
 {
 	struct tcp_server_conn *conn = arg;
-	size_t len = bufferev_bytes_available(be);
-	void *buf = malloc(len);
-	if (buf) {
-		bufferev_read(be, buf, len);
-		channel_enqueue(conn->channel, buf, len);
-		free(buf);
-	}
+	channel_enqueue_buffer_queue(conn->channel, bufferev_rx_queue(be));
 }
 
 static void conn_event_cb(struct bufferev *be, int event, void *arg)

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -200,8 +200,8 @@ int tlv_packet_get_u64(struct tlv_packet *p, uint32_t value_type, uint64_t *valu
 	return 0;
 }
 
-struct tlv_packet * tlv_packet_add_child_raw(struct tlv_packet *p,
-		const void *val, size_t len)
+static struct tlv_packet *
+tlv_packet_add_child_raw(struct tlv_packet *p, const void *val, size_t len)
 {
 	int packet_len = tlv_packet_len(p);
 	int new_len = packet_len + len;
@@ -213,10 +213,18 @@ struct tlv_packet * tlv_packet_add_child_raw(struct tlv_packet *p,
 	return p;
 }
 
-struct tlv_packet * tlv_packet_add_child(struct tlv_packet *p,
-		struct tlv_packet *child)
+struct tlv_packet *
+tlv_packet_add_child(struct tlv_packet *p, struct tlv_packet *child)
 {
 	p = tlv_packet_add_child_raw(p, child, tlv_packet_len(child));
+	tlv_packet_free(child);
+	return p;
+}
+
+struct tlv_packet *
+tlv_packet_merge_child(struct tlv_packet *p, struct tlv_packet *child)
+{
+	p = tlv_packet_add_child_raw(p, child->buf, tlv_packet_len(child) - sizeof(child->h));
 	tlv_packet_free(child);
 	return p;
 }

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -56,10 +56,10 @@ void *tlv_packet_iterate(struct tlv_iterator *i, size_t *len);
 
 char *tlv_packet_iterate_str(struct tlv_iterator *i);
 
-struct tlv_packet * tlv_packet_add_child_raw(struct tlv_packet *p,
-		const void *val, size_t len);
-
 struct tlv_packet * tlv_packet_add_child(struct tlv_packet *p,
+		struct tlv_packet *child);
+
+struct tlv_packet * tlv_packet_merge_child(struct tlv_packet *p,
 		struct tlv_packet *child);
 
 struct tlv_packet * tlv_packet_add_raw(struct tlv_packet *p,


### PR DESCRIPTION
In #39 there was still more work to do on the UDP side, and this implements the missing pieces.

Much of the work is foundational, such as teaching bufferev and network_client how to properly handle UDP sockets, channels how to add extra data, etc. The actual UDP channel support is implemented in: b2da5ef62d5be8f6bf137b82a0e1c813ad0112fd

To test, I have been using @darkoperator 's pentest plugin and scanning remote networks https://github.com/darkoperator/Metasploit-Plugins

First:
```
mettle$ ./build/linux.x86_64/bin/mettle -u tcp://localhost:4444 -d
```

Then this RC script
```
use exploit/multi/handler
set payload linux/x86/mettle_reverse_tcp
set lhost 127.0.0.1
run -j
sleep 4
load pentest
pivot_network_discover -s 1 -t -u
```
 - [x] Land https://github.com/rapid7/metasploit-framework/pull/7774, since receiving on a UDP pivot is otherwise broken without this fix.
 - [x] Retest the changes for that PR against this one as well.
 - [x] Run other UDP modules, such as the pentest plugin above, to verify that mettle is resilient and works as expected in various circumstances.