### PR TITLE
fix make on darwin (OSX)

### DIFF
--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -17,6 +17,13 @@ case $host_os in
 	*linux*)
 		CPPFLAGS="$CPPFLAGS -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE"
 		;;
+	*darwin*)
+		AC_CHECK_FUNCS([reallocarray strlcat strlcpy strtonum])
+		AM_CONDITIONAL([HAVE_REALLOCARRAY], [test "x$ac_cv_func_reallocarray" = xyes])
+		AM_CONDITIONAL([HAVE_STRLCAT], [test "x$ac_cv_func_strlcat" = xyes])
+		AM_CONDITIONAL([HAVE_STRLCPY], [test "x$ac_cv_func_strlcpy" = xyes])
+		AM_CONDITIONAL([HAVE_STRTONUM], [test "x$ac_cv_func_strtonum" = xyes])
+		;;
 	*mingw*)
 		HOST_OS=win
 		CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE -D_POSIX -D_POSIX_SOURCE -D__USE_MINGW_ANSI_STDIO"


### PR DESCRIPTION
This change should fix the build on OSX, allowing you to build a native mach-o stageless mettle binary with 
```
brew install automake coreutils
make
```
Error before:
```
Building mettle for native
In file included from mettle/mettle/src/mettle.c:9:
mettle/mettle/include/compat/string.h:35:8: error: expected parameter declarator
size_t strlcpy(char *dst, const char *src, size_t siz);
       ^
/usr/include/secure/_string.h:105:44: note: expanded from macro 'strlcpy'
  __builtin___strlcpy_chk (dest, src, len, __darwin_obsz (dest))
                                           ^
/usr/include/secure/_common.h:39:62: note: expanded from macro '__darwin_obsz'
#define __darwin_obsz(object) __builtin_object_size (object, _USE_FORTIFY_LEVEL > 1 ? 1 : 0)
                                                             ^
/usr/include/secure/_common.h:30:32: note: expanded from macro '_USE_FORTIFY_LEVEL'
#    define _USE_FORTIFY_LEVEL 2

```

