### PR TITLE
fix build on OS X

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -15,6 +15,10 @@ ERRFILE=$(BUILD)/build.err
 DEPS=$(ROOT)/deps
 OUTPUTDIR=$(BUILD)/data
 
+ifeq "$(shell uname -s)" "Darwin"
+	export SDKROOT=macosx10.8
+endif
+
 CFLAGS:=$(CFLAGS) -Os -I$(BUILD)/include
 ifeq (,$(findstring mingw,$(TARGET)))
     CFLAGS:=$(CFLAGS) -fPIE
@@ -35,10 +39,12 @@ ifneq "$(HOST)" ""
 endif
 
 # if Debug is enabled, build with debug symbols, otherwise strip the symbol table
-ifeq "$(D)" "1"
-    CFLAGS:=$(CFLAGS) -g
-else
-    LDFLAGS:=$(LDFLAGS) -s
+ifeq "$(shell uname -s)" "Linux"
+    ifeq "$(D)" "1"
+        CFLAGS:=$(CFLAGS) -g
+    else
+        LDFLAGS:=$(LDFLAGS) -s
+    endif
 endif
 
 ENV=LDFLAGS="-L$(BUILD)/lib $(LDFLAGS)" CC="$(CC)" CPP="$(CPP)" AR="$(AR)" RANLIB="$(RANLIB)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)"

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -30,9 +30,9 @@ esac
 
 AM_CONDITIONAL([HOST_WIN],     [test x$HOST_OS = xwin])
 
-CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function"
-
 CHECK_LIBC_COMPAT
+
+CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function"
 
 AC_CONFIG_FILES([
 	Makefile


### PR DESCRIPTION
This fixes a problem when mettle checks for OS features where it fails many of them due to -Werror. Instead set that after everything has been tested for.

This also sets a base SDK level and disables default flags that are ignored with the current OS X toolchain.