### PR TITLE
add http client to libmettle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ To generate a payload with Mettle:
 mettle = MetasploitPayloads::Mettle.new(platform_triple, config={})
 ```
 
-The available platform triples are:
+The available platform triples for Linux targets are:
+
 * `aarch64-linux-musl`
 * `armv5l-linux-musleabi`
 * `armv5b-linux-musleabi`
@@ -45,6 +46,20 @@ The available platform triples are:
 * `mipsel-linux-muslsf`
 * `mips64-linux-muslsf`
 * `s390x-linux-musl`
+
+For Mingw32-64 Windows targets, the following triples are added. On up-to-date
+Debian / Ubuntu systems, the `mingw-w64` package will install both toolchains.
+
+* `x86_64-w64-mingw32`
+* `i686-w64-mingw32`
+
+For macOS/iOS builds, the following triples are added. To target older MacOSX
+versions, see https://github.com/phracker/MacOSX-SDKs to get the appropriate
+SDK folder.
+
+* `arm-iphone-darwin`
+* `arm64-iphone-darwin`
+* `x86_64-apple-darwin`
 
 Available config options are:
 * `:uri` - the uri to connect back to

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -16,7 +16,11 @@ DEPS=$(ROOT)/deps
 OUTPUTDIR=$(BUILD)/data
 
 ifeq "$(shell uname -s)" "Darwin"
-	export SDKROOT=macosx10.8
+    ifneq (,$(findstring iphone,$(TARGET)))
+        export SDKROOT=$(shell xcrun --sdk iphoneos --show-sdk-path)
+    else
+        export SDKROOT=$(shell xcrun --sdk macosx --show-sdk-path)
+    endif
 endif
 
 CFLAGS:=$(CFLAGS) -Os -I$(BUILD)/include

--- a/make/Makefile.curl
+++ b/make/Makefile.curl
@@ -1,4 +1,4 @@
-LIBCURL_VERSION=7.46.0
+LIBCURL_VERSION=7.53.1
 
 $(BUILD)/lib/libcurl.a: build/tools \
 	$(BUILD)/lib/libmbedtls.a
@@ -13,14 +13,32 @@ $(BUILD)/lib/libcurl.a: build/tools \
 		$(ENV) ./$(CONFIGURE) \
 		--without-ssl --with-mbedtls=$(BUILD) \
 		--without-libpsl \
-		--disable-ldap --without-libidn --without-libssh2 \
+		--enable-optimize \
+		--disable-dict  \
+		--disable-gopher  \
+		--disable-ftp  \
+		--disable-imap  \
+		--disable-ldap  \
+		--disable-ldaps  \
+		--disable-pop3  \
+		--disable-proxy  \
+		--disable-rtsp  \
+		--disable-smb  \
+		--disable-smtp  \
+		--disable-telnet  \
+		--disable-tftp  \
+		--without-libidn  \
+		--without-librtmp  \
+		--without-libssh2  \
+		--without-zlib  \
+		--disable-shared \
 		--without-ca-bundle --without-ca-path \
 		--enable-threaded-resolver \
 		ac_cv_header_sys_poll_h=no \
 		$(LOGBUILD)
 	@echo "Building curl for $(TARGET)"
 	@cd $(BUILD)/curl; \
-		$(MAKE) $(LOGBUILD) ; \
+		$(MAKE) lib $(LOGBUILD) ; \
 		$(MAKE_INSTALL) $(LOGBUILD)
 
 curl: $(BUILD)/lib/libcurl.a

--- a/make/Makefile.libdnet
+++ b/make/Makefile.libdnet
@@ -4,7 +4,8 @@ $(BUILD)/libdnet/configure:
 	@cd $(BUILD); \
 		rm -fr libdnet; \
 		$(TAR) zxf $(ROOT)/deps/libdnet-1.12.tar.gz; \
-		mv libdnet-1.12 libdnet
+		mv libdnet-1.12 libdnet; \
+		cp libdnet/src/route-none.c libdnet/src/route-linux.c
 
 DNET_CONFIGURE_FLAGS:=""
 ifneq "$(TARGET)" "native"

--- a/make/Makefile.libdnet
+++ b/make/Makefile.libdnet
@@ -8,7 +8,11 @@ $(BUILD)/libdnet/configure:
 
 DNET_CONFIGURE_FLAGS:=""
 ifneq "$(TARGET)" "native"
-    DNET_CONFIGURE_FLAGS:=ac_cv_dnet_linux_procfs=yes ac_cv_dnet_bsd_bpf=no
+    ifneq (,$(findstring iphone,$(TARGET)))
+        DNET_CONFIGURE_FLAGS:=ac_cv_dnet_bsd_bpf=no
+    else
+        DNET_CONFIGURE_FLAGS:=ac_cv_dnet_linux_procfs=yes ac_cv_dnet_bsd_bpf=no
+    endif
 endif
 
 $(BUILD)/libdnet/Makefile: build/tools $(BUILD)/libdnet/configure $(DNET_DEPS)

--- a/make/Makefile.libdnet
+++ b/make/Makefile.libdnet
@@ -4,8 +4,7 @@ $(BUILD)/libdnet/configure:
 	@cd $(BUILD); \
 		rm -fr libdnet; \
 		$(TAR) zxf $(ROOT)/deps/libdnet-1.12.tar.gz; \
-		mv libdnet-1.12 libdnet; \
-		cp libdnet/src/route-none.c libdnet/src/route-linux.c
+		mv libdnet-1.12 libdnet
 
 DNET_CONFIGURE_FLAGS:=""
 ifneq "$(TARGET)" "native"

--- a/make/Makefile.libev
+++ b/make/Makefile.libev
@@ -16,6 +16,7 @@ $(BUILD)/libev/Makefile: build/tools $(BUILD)/libev/configure $(LIBEV_DEPS)
 $(BUILD)/lib/libev.a: $(BUILD)/libev/Makefile
 	@echo "Building libev for $(TARGET)"
 	@cd $(BUILD)/libev; \
+		sed -i -- 's/HAVE_CLOCK_GETTIME 1/HAVE_CLOCK_GETTIME 0/g' config.h; \
 		$(MAKE) $(LOGBUILD) ; \
 		$(MAKE_INSTALL) $(LOGBUILD)
 

--- a/make/Makefile.libev
+++ b/make/Makefile.libev
@@ -16,7 +16,6 @@ $(BUILD)/libev/Makefile: build/tools $(BUILD)/libev/configure $(LIBEV_DEPS)
 $(BUILD)/lib/libev.a: $(BUILD)/libev/Makefile
 	@echo "Building libev for $(TARGET)"
 	@cd $(BUILD)/libev; \
-		sed -i -- 's/HAVE_CLOCK_GETTIME 1/HAVE_CLOCK_GETTIME 0/g' config.h; \
 		$(MAKE) $(LOGBUILD) ; \
 		$(MAKE_INSTALL) $(LOGBUILD)
 

--- a/make/Makefile.libev
+++ b/make/Makefile.libev
@@ -1,4 +1,4 @@
-LIBEV_VERSION=4.22
+LIBEV_VERSION=4.24
 
 $(BUILD)/libev/configure:
 	@echo "Unpacking libev for $(TARGET)"

--- a/make/Makefile.mbedtls
+++ b/make/Makefile.mbedtls
@@ -1,4 +1,4 @@
-MBEDTLS_VERSION=2.3.0
+MBEDTLS_VERSION=2.4.0
 
 MBEDTLS_ENV=
 ifneq (,$(findstring mingw,$(TARGET)))
@@ -8,11 +8,13 @@ endif
 
 $(BUILD)/lib/libmbedtls.a: build/tools
 	@echo "Unpacking mbedtls for $(TARGET)"
-	@mkdir -p $(BUILD)
-	@cd $(BUILD); \
+	@mkdir -p $(BUILD)/lib
+	@mkdir -p $(BUILD)/include
+	cd $(BUILD); \
 		rm -fr $(BUILD)/mbedtls; \
 		$(TAR) zxf $(DEPS)/mbedtls-$(MBEDTLS_VERSION)-apache.tgz; \
-		mv mbedtls-$(MBEDTLS_VERSION) mbedtls
+		mv mbedtls-$(MBEDTLS_VERSION) mbedtls; \
+		cp $(DEPS)/mbedtls-config.h mbedtls/include/mbedtls/config.h
 	@echo "Building mbedtls for $(TARGET)"
 	@cd $(BUILD)/mbedtls; \
 		$(ENV) $(MBEDTLS_ENV) $(MAKE) $(LOGBUILD) ; \

--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -1,3 +1,4 @@
+include make/Makefile.curl
 include make/Makefile.libdnet
 include make/Makefile.libev
 include make/Makefile.libeio
@@ -21,6 +22,7 @@ $(ROOT)/mettle/configure: $(ROOT)/mettle/configure.ac
 		autoreconf -i $(LOGBUILD)
 
 $(BUILD)/mettle/Makefile: build/tools $(ROOT)/mettle/configure \
+	$(BUILD)/lib/libcurl.a \
 	$(BUILD)/lib/libeio.a \
 	$(BUILD)/lib/libev.a \
 	$(BUILD)/lib/libmbedtls.a \

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -15,6 +15,17 @@ ifneq "$(TARGET)" "native"
         LD=$(TARGET)-ld
         RANLIB=$(TARGET)-ranlib
     endif
+    ifneq (,$(findstring iphone,$(TARGET)))
+        ADDFLAGS:=-isysroot $(SDKROOT)
+        ifneq (,$(findstring arm,$(TARGET)))
+            ADDFLAGS:=$(ADDFLAGS) -mios-version-min=7.1 -arch armv7
+        else
+            ADDFLAGS:=$(ADDFLAGS) -mios-version-min=7.1 -arch arm64
+        endif
+        CFLAGS:=$(CFLAGS) $(ADDFLAGS)
+        CPPFLAGS:=$(CPPFLAGS) $(ADDFLAGS)
+        LDFLAGS:=$(LDFLAGS) $(ADDFLAGS)
+    endif
 endif
 
 TAR=tar

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -3,12 +3,14 @@ AM_CPPFLAGS = -I$(top_srcdir)/include/compat
 lib_LTLIBRARIES = libmettle.la
 
 libmettle_la_LIBADD = -ldnet
+libmettle_la_LIBADD += -lcurl
 libmettle_la_LIBADD += -leio
 libmettle_la_LIBADD += -lev
-libmettle_la_LIBADD += -lmbedcrypto
 libmettle_la_LIBADD += -lmbedtls
+libmettle_la_LIBADD += -lmbedcrypto
 libmettle_la_LIBADD += -lpthread
 libmettle_la_LIBADD += -lsigar
+libmettle_la_LIBADD += -lz
 
 libmettle_la_SOURCES = mettle.c
 libmettle_la_SOURCES += argv_split.c
@@ -16,11 +18,12 @@ libmettle_la_SOURCES += base64.c
 libmettle_la_SOURCES += bufferev.c
 libmettle_la_SOURCES += buffer_queue.c
 libmettle_la_SOURCES += channel.c
+libmettle_la_SOURCES += coreapi.c
+libmettle_la_SOURCES += http_client.c
 libmettle_la_SOURCES += log.c
 libmettle_la_SOURCES += network_client.c
 libmettle_la_SOURCES += network_server.c
 libmettle_la_SOURCES += tlv.c
-libmettle_la_SOURCES += coreapi.c
 libmettle_la_SOURCES += stdapi/stdapi.c
 if HOST_WIN
 libmettle_la_SOURCES += inet_ntop.c inet_pton.c

--- a/mettle/src/http_client.c
+++ b/mettle/src/http_client.c
@@ -1,0 +1,353 @@
+#include <ctype.h>
+#include <stdlib.h>
+
+#include <curl/curl.h>
+#include <eio.h>
+#include <zlib.h>
+
+#include "buffer_queue.h"
+#include "http_client.h"
+#include "log.h"
+
+struct http_conn {
+	CURL *easy_handle;
+	CURLcode res;
+	char *url;
+	char error[CURL_ERROR_SIZE];
+	void (*cb)(struct http_conn *, void *arg);
+	void *cb_arg;
+
+	void *content;
+	size_t content_len;
+
+	struct curl_slist *request_headers;
+	struct curl_slist *response_headers;
+	struct buffer_queue *response;
+};
+
+char *http_conn_response(struct http_conn *conn)
+{
+	void *data = NULL;
+	ssize_t len = buffer_queue_remove_all(conn->response, &data);
+	if (len > 0) {
+		((char *)data)[len - 1] = '\0';
+	}
+	return data;
+}
+
+void *http_conn_response_raw(struct http_conn *conn, ssize_t *len)
+{
+	void *data = NULL;
+	*len = buffer_queue_remove_all(conn->response, &data);
+	return data;
+}
+
+int http_conn_response_code(struct http_conn *conn)
+{
+	long code = -1;
+	curl_easy_getinfo(conn->easy_handle, CURLINFO_RESPONSE_CODE, &code);
+	return code;
+}
+
+const char *http_conn_header_value(struct http_conn *conn, const char *key)
+{
+    if (conn->response_headers == NULL) {
+        return NULL;
+    }
+
+    char *key_search = NULL;
+    int rc = asprintf(&key_search, "%s: ", key);
+    if (rc > 0 && key_search) {
+        size_t key_len = strlen(key_search);
+        struct curl_slist *header = conn->response_headers;
+        do {
+            if (!strncmp(key_search, header->data, key_len)) {
+                free(key_search);
+                return header->data + key_len;
+            }
+            header = header->next;
+        } while (header);
+    }
+    free(key_search);
+    return NULL;
+}
+
+void http_conn_free(struct http_conn *conn)
+{
+	if (conn) {
+		free(conn->url);
+		if (conn->response) {
+			buffer_queue_free(conn->response);
+		}
+		if (conn->request_headers) {
+			curl_slist_free_all(conn->request_headers);
+		}
+		if (conn->response_headers) {
+			curl_slist_free_all(conn->response_headers);
+		}
+		if (conn->easy_handle) {
+			curl_easy_cleanup(conn->easy_handle);
+		}
+		if (conn->content) {
+			free(conn->content);
+		}
+		free(conn);
+	}
+}
+
+static size_t write_cb(void *buf, size_t size, size_t nmemb, void *arg)
+{
+	size_t len = size * nmemb;
+	struct http_conn *conn = arg;
+	return (buffer_queue_add(conn->response, buf, len) == 0) ? len : 0;
+}
+
+static size_t header_cb(void *buf, size_t size, size_t nmemb, void *arg)
+{
+    struct http_conn *conn = arg;
+    size_t len = size * nmemb;
+
+	/*
+	 * Ignore redirect headers
+	 */
+    if (http_conn_response_code(conn) == 302) {
+        return len;
+    }
+
+    if (len > 2) {
+        char *header = malloc(len + 1);
+        if (header) {
+            memcpy(header, buf, len);
+            header[len] = '\0';
+            for (size_t end = len - 1; end > 0 && isspace(header[end]); end--) {
+                header[end] = '\0';
+            }
+            conn->response_headers = curl_slist_append(conn->response_headers, header);
+            free(header);
+        }
+    }
+    return len;
+}
+
+static int request_done(struct eio_req *req)
+{
+	struct http_conn *conn = req->data;
+	if (conn->cb) {
+		conn->cb(conn, conn->cb_arg);
+	}
+	http_conn_free(conn);
+	return 0;
+}
+
+static void request(struct eio_req *req)
+{
+	struct http_conn *conn = req->data;
+	conn->res = curl_easy_perform(conn->easy_handle);
+}
+
+static void *compress_content(const void *content, size_t content_len, size_t *compressed_len)
+{
+	int result;
+	z_stream strm = { 0 };
+
+	/*
+	 * Avoid diminishing returns
+	 */
+	if (content_len < 256) {
+		return NULL;
+	}
+
+	size_t comp_len = compressBound(content_len);
+	void *buf = malloc(comp_len);
+
+	if (buf == NULL) {
+		return NULL;
+	}
+
+	result = deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS | 16,
+		MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+
+	if (result != Z_OK) {
+		switch (result) {
+			case Z_MEM_ERROR:
+			case Z_BUF_ERROR:
+				break;
+		}
+		free(buf);
+		buf = NULL;
+		goto out;
+	}
+
+	strm.next_in = (Bytef *)content;
+	strm.avail_in = content_len;
+	strm.next_out = (Bytef *)buf;
+	strm.avail_out = content_len;
+
+	result = deflate(&strm, Z_FINISH);
+
+	if (result != Z_STREAM_END) {
+		free(buf);
+		buf = NULL;
+	} else {
+		*compressed_len = strm.total_out;
+	}
+
+out:
+	deflateEnd(&strm);
+	return buf;
+}
+
+int http_request(const char *url, enum http_request req,
+	void (*cb)(struct http_conn *, void *arg), void *cb_arg,
+	struct http_request_data *data, struct http_request_opts *opts)
+{
+	struct http_conn *conn = calloc(1, sizeof *conn);
+	if (conn == NULL) {
+		return -1;
+	}
+
+	conn->url = strdup(url);
+	if (conn->url == NULL) {
+		goto err;
+	}
+
+	conn->response = buffer_queue_new();
+	if (conn->response == NULL) {
+		goto err;
+	}
+
+	conn->cb = cb;
+	conn->cb_arg = cb_arg;
+
+	conn->easy_handle = curl_easy_init();
+	if (conn->easy_handle == NULL) {
+		goto err;
+	}
+
+	curl_easy_setopt(conn->easy_handle, CURLOPT_URL, conn->url);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_HEADERFUNCTION, header_cb);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_HEADERDATA, conn);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_WRITEFUNCTION, write_cb);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_WRITEDATA, conn);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_ERRORBUFFER, conn->error);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_PRIVATE, conn);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_FOLLOWLOCATION, 1L);
+
+	/*
+	 * Timeout after 60 seconds running < 1 byte/sec
+	 */
+	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_TIME, 60L);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_LIMIT, 1L);
+
+	switch (req) {
+		case http_request_get:
+			break;
+		case http_request_post:
+			curl_easy_setopt(conn->easy_handle, CURLOPT_POST, 1L);
+			break;
+		case http_request_put:
+			curl_easy_setopt(conn->easy_handle, CURLOPT_PUT, 1L);
+			break;
+		case http_request_delete:
+			curl_easy_setopt(conn->easy_handle, CURLOPT_CUSTOMREQUEST, "DELETE");
+			break;
+	}
+
+	if (data) {
+		if (data->headers) {
+			const struct http_request_header *header = data->headers;
+			while (header) {
+				char *header_str = NULL;
+				int rc = asprintf(&header_str, "%s: %s", header->key, header->value);
+				if (rc > 0) {
+					conn->request_headers = curl_slist_append(conn->request_headers, header_str);
+				}
+				free(header_str);
+				header++;
+			}
+		}
+
+		if (data->content) {
+			char *content_type = NULL;
+			int rc = asprintf(&content_type, "Content-Type: %s",
+					data->content_type ? data->content_type : "application/json");
+			if (rc > 0) {
+				conn->request_headers = curl_slist_append(conn->request_headers, content_type);
+			}
+
+			if (data->flags & HTTP_DATA_COMPRESS) {
+				conn->content = compress_content(data->content,
+						data->content_len, &conn->content_len);
+				if (conn->content) {
+					conn->request_headers = curl_slist_append(conn->request_headers,
+								"Content-Encoding: gzip");
+				}
+			}
+
+			if (conn->content == NULL) {
+				conn->content = malloc(data->content_len);
+				if (conn->content) {
+					memcpy(conn->content, data->content, data->content_len);
+					conn->content_len = data->content_len;
+				}
+			}
+
+			if (conn->content) {
+				curl_easy_setopt(conn->easy_handle, CURLOPT_POSTFIELDS, conn->content);
+				curl_easy_setopt(conn->easy_handle, CURLOPT_POSTFIELDSIZE, (long)conn->content_len);
+			}
+		}
+	}
+
+	if (opts) {
+		if (opts->ca_type == http_ca_type_path) {
+			curl_easy_setopt(conn->easy_handle, CURLOPT_CAPATH, opts->ca);
+		} else if (opts->ca_type == http_ca_type_bundle) {
+			curl_easy_setopt(conn->easy_handle, CURLOPT_CAINFO, opts->ca);
+		}
+
+		if (opts->proxy.type != http_proxy_none) {
+			curl_easy_setopt(conn->easy_handle, CURLOPT_PROXY, opts->proxy.hostname);
+			curl_easy_setopt(conn->easy_handle, CURLOPT_PROXYPORT, opts->proxy.port);
+
+			if (opts->proxy.auth_type != http_auth_none) {
+				char *userpwd = NULL;
+				int rc = asprintf(&userpwd, "%s:%s",
+						opts->proxy.auth_user ? opts->proxy.auth_user : "",
+						opts->proxy.auth_pass ? opts->proxy.auth_pass : "");
+				if (rc > 0) {
+					curl_easy_setopt(conn->easy_handle, CURLOPT_PROXYUSERPWD, userpwd);
+					if (opts->proxy.auth_type == http_auth_basic) {
+						curl_easy_setopt(conn->easy_handle, CURLOPT_PROXYAUTH, CURLAUTH_BASIC);
+					} else if (opts->proxy.auth_type == http_auth_digest) {
+						curl_easy_setopt(conn->easy_handle, CURLOPT_PROXYAUTH, CURLAUTH_DIGEST);
+					}
+					free(userpwd);
+				}
+			}
+		}
+
+		if (opts->flags & HTTP_OPTS_VERBOSE) {
+			curl_easy_setopt(conn->easy_handle, CURLOPT_VERBOSE, 1L);
+		}
+		if (opts->flags & HTTP_OPTS_SKIP_TLS_VALIDATION) {
+			curl_easy_setopt(conn->easy_handle, CURLOPT_SSL_VERIFYPEER, 0L);
+			curl_easy_setopt(conn->easy_handle, CURLOPT_SSL_VERIFYHOST, 0L);
+		} else {
+			curl_easy_setopt(conn->easy_handle, CURLOPT_SSL_VERIFYPEER, 1L);
+			curl_easy_setopt(conn->easy_handle, CURLOPT_SSL_VERIFYHOST, 2L);
+		}
+	}
+
+	if (conn->request_headers) {
+		curl_easy_setopt(conn->easy_handle, CURLOPT_HTTPHEADER, conn->request_headers);
+	}
+
+	eio_custom(request, 0, request_done, conn);
+
+	return 0;
+
+err:
+	http_conn_free(conn);
+	return -1;
+}

--- a/mettle/src/http_client.h
+++ b/mettle/src/http_client.h
@@ -1,0 +1,81 @@
+#ifndef METTLE_HTTP_CLIENT_H
+#define METTLE_HTTP_CLIENT_H
+
+#include <ev.h>
+
+enum http_request {
+	http_request_get,
+	http_request_post,
+	http_request_put,
+	http_request_delete
+};
+
+enum http_auth_type {
+	http_auth_none,
+	http_auth_basic,
+	http_auth_digest
+};
+
+enum http_ca_type {
+	http_ca_type_none,
+	http_ca_type_path,
+	http_ca_type_bundle
+};
+
+enum http_proxy_type {
+	http_proxy_none,
+	http_proxy_http,
+	http_proxy_socks5
+};
+
+struct http_request_data {
+
+	struct http_request_header {
+		const char *key, *value;
+	} *headers;
+
+#define HTTP_DATA_COMPRESS (1 << 0)
+	unsigned int flags;
+	const char *content_type;
+	const void *content;
+	size_t content_len;
+};
+
+struct http_request_opts {
+
+	enum http_ca_type ca_type;
+	const char *ca;
+
+	struct {
+		enum http_proxy_type type;
+		const char *hostname;
+		uint16_t port;
+		enum http_auth_type auth_type;
+		const char *auth_user;
+		const char *auth_pass;
+	} proxy;
+
+#define HTTP_OPTS_VERBOSE             (1 << 0)
+#define HTTP_OPTS_SKIP_TLS_VALIDATION (1 << 1)
+	unsigned int flags;
+
+	enum http_auth_type auth_type;
+	const char *auth_user;
+	const char *auth_pass;
+};
+
+struct http_conn;
+
+int http_request(const char *url, enum http_request req,
+	void (*cb)(struct http_conn *, void *arg), void *cb_arg,
+	struct http_request_data *data, struct http_request_opts *opts);
+
+char *http_conn_response(struct http_conn *conn);
+
+void *http_conn_response_raw(struct http_conn *conn, ssize_t *len);
+
+int http_conn_response_code(struct http_conn *conn);
+
+const char *http_conn_header_value(struct http_conn *conn, const char *key);
+
+#endif

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -76,6 +76,7 @@ heartbeat_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 int start_heartbeat(struct mettle *m)
 {
 	ev_timer_init(&m->heartbeat, heartbeat_cb, 0, 5.0);
+	m->heartbeat.data = m;
 	ev_timer_start(m->loop, &m->heartbeat);
 	return 0;
 }

--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -503,7 +503,7 @@ resolve(struct eio_req *req)
 static void
 reconnect_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 {
-	struct network_client *nc = (struct network_client *)w;
+	struct network_client *nc = w->data;
 
 	if (nc->state != network_client_closed || nc->num_servers == 0) {
 		return;
@@ -516,6 +516,7 @@ reconnect_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 int network_client_start(struct network_client *nc)
 {
 	ev_timer_init(&nc->connect_timer, reconnect_cb, 0, 1.0);
+	nc->connect_timer.data = nc;
 	ev_timer_start(nc->loop, &nc->connect_timer);
 	return 0;
 }

--- a/mettle/src/stdapi/net/resolve.c
+++ b/mettle/src/stdapi/net/resolve.c
@@ -32,10 +32,10 @@ void resolve_host_async(struct eio_req *req)
 		.ai_family = addr_type,
 	};
 
-        struct tlv_iterator i = {
-                .packet = ctx->req,
-                .value_type = TLV_TYPE_HOST_NAME,
-        };
+	struct tlv_iterator i = {
+		.packet = ctx->req,
+		.value_type = TLV_TYPE_HOST_NAME,
+	};
 	const char *hostname;
 	while ((hostname = tlv_packet_iterate_str(&i))) {
 		struct addrinfo *resolved_host = NULL;

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -9,6 +9,9 @@
 #else
 #include <arpa/inet.h>
 #endif
+#ifdef __APPLE__
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#endif
 #include <endian.h>
 
 #include <pthread.h>

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -9,9 +9,6 @@
 #else
 #include <arpa/inet.h>
 #endif
-#ifdef __APPLE__
-#define htole32(x) OSSwapHostToLittleInt32(x)
-#endif
 #include <endian.h>
 
 #include <pthread.h>


### PR DESCRIPTION
This is basically a simplified event-driven wrapper to libcurl. This also updates the build to link libcurl and reduce the size of mbedtls.