### PR TITLE
add parallel make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 all: mettle
 
 include make/Makefile.common
@@ -9,3 +10,118 @@ distclean:
 
 clean:
 	@rm -fr $(BUILD)/mettle
+
+all-parallel: \
+	i686-w64-mingw32.build \
+	x86_64-linux-musl.build \
+	i486-linux-musl.build \
+	aarch64-linux-musl.build \
+	armv5l-linux-musleabi.build \
+	armv5b-linux-musleabi.build \
+	powerpc-linux-muslsf.build \
+	powerpc64le-linux-musl.build \
+	mips-linux-muslsf.build \
+	mipsel-linux-muslsf.build \
+	mips64-linux-muslsf.build \
+	s390x-linux-musl.build
+
+clean-parallel: \
+	i686-w64-mingw32.clean \
+	x86_64-linux-musl.clean \
+	i486-linux-musl.clean \
+	aarch64-linux-musl.clean \
+	armv5l-linux-musleabi.clean \
+	armv5b-linux-musleabi.clean \
+	powerpc-linux-muslsf.clean \
+	powerpc64le-linux-musl.clean \
+	mips-linux-muslsf.clean \
+	mipsel-linux-muslsf.clean \
+	mips64-linux-muslsf.clean \
+	s390x-linux-musl.clean
+
+distclean-parallel: \
+	i686-w64-mingw32.distclean \
+	x86_64-linux-musl.distclean \
+	i486-linux-musl.distclean \
+	aarch64-linux-musl.distclean \
+	armv5l-linux-musleabi.distclean \
+	armv5b-linux-musleabi.distclean \
+	powerpc-linux-muslsf.distclean \
+	powerpc64le-linux-musl.distclean \
+	mips-linux-muslsf.distclean \
+	mipsel-linux-muslsf.distclean \
+	mips64-linux-muslsf.distclean \
+	s390x-linux-musl.distclean
+
+i686-w64-mingw32.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=i686-w64-mingw32
+i686-w64-mingw32.clean:
+	make TARGET=i686-w64-mingw32 clean
+i686-w64-mingw32.distclean:
+	make TARGET=i686-w64-mingw32 distclean
+x86_64-linux-musl.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=x86_64-linux-musl
+x86_64-linux-musl.clean:
+	make TARGET=x86_64-linux-musl clean
+x86_64-linux-musl.distclean:
+	make TARGET=x86_64-linux-musl distclean
+i486-linux-musl.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=i486-linux-musl
+i486-linux-musl.clean:
+	make TARGET=i486-linux-musl clean
+i486-linux-musl.distclean:
+	make TARGET=i486-linux-musl distclean
+aarch64-linux-musl.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=aarch64-linux-musl
+aarch64-linux-musl.clean:
+	make TARGET=aarch64-linux-musl clean
+aarch64-linux-musl.distclean:
+	make TARGET=aarch64-linux-musl distclean
+armv5l-linux-musleabi.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=armv5l-linux-musleabi
+armv5l-linux-musleabi.clean:
+	make TARGET=armv5l-linux-musleabi clean
+armv5l-linux-musleabi.distclean:
+	make TARGET=armv5l-linux-musleabi distclean
+armv5b-linux-musleabi.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=armv5b-linux-musleabi
+armv5b-linux-musleabi.clean:
+	make TARGET=armv5b-linux-musleabi clean
+armv5b-linux-musleabi.distclean:
+	make TARGET=armv5b-linux-musleabi distclean
+powerpc-linux-muslsf.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=powerpc-linux-muslsf
+powerpc-linux-muslsf.clean:
+	make TARGET=powerpc-linux-muslsf clean
+powerpc-linux-muslsf.distclean:
+	make TARGET=powerpc-linux-muslsf distclean
+powerpc64le-linux-musl.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=powerpc64le-linux-musl
+powerpc64le-linux-musl.clean:
+	make TARGET=powerpc64le-linux-musl clean
+powerpc64le-linux-musl.distclean:
+	make TARGET=powerpc64le-linux-musl distclean
+mips-linux-muslsf.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=mips-linux-muslsf
+mips-linux-muslsf.clean:
+	make TARGET=mips-linux-muslsf clean
+mips-linux-muslsf.distclean:
+	make TARGET=mips-linux-muslsf distclean
+mipsel-linux-muslsf.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=mipsel-linux-muslsf
+mipsel-linux-muslsf.clean:
+	make TARGET=mipsel-linux-muslsf clean
+mipsel-linux-muslsf.distclean:
+	make TARGET=mipsel-linux-muslsf distclean
+mips64-linux-muslsf.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=mips64-linux-muslsf
+mips64-linux-muslsf.clean:
+	make TARGET=mips64-linux-muslsf clean
+mips64-linux-muslsf.distclean:
+	make TARGET=mips64-linux-muslsf distclean
+s390x-linux-musl.build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=s390x-linux-musl
+s390x-linux-musl.clean:
+	make TARGET=s390x-linux-musl clean
+s390x-linux-musl.distclean:
+	make TARGET=s390x-linux-musl distclean

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ git submodule init; git submodule update
 ```
 after cloning.
 
-To build the gem (currently requires linux):
+To build the gem (currently requires Linux or macOS):
 
 ```
 rake build
@@ -24,6 +24,26 @@ To completely reset your dev environment and delete all binary artifacts:
 ```
 rake mettle:ultraclean
 ```
+
+Make Targets
+------------
+
+For general development, there are a few make targets defined:
+
+Running `make` will build for the local environment. E.g. if you're on macOS,
+it will build for macOS using your native compiler and tools.
+
+`make TARGET=triple` will build for a specific host triple. See below for some
+common ones.
+
+`make clean` will clean the 'mettle' directory for the current build target
+
+`make distclean` will clean the entire build target`
+
+`make all-parallel` will build for every known target, useful with '-j' to build multiple targets at once.
+
+`make clean-parallel` and `make distclean-parallel` do similar for all targets.
+
 
 Gem API
 -------

--- a/genmakefile.py
+++ b/genmakefile.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+arches = file('ARCHES').read().splitlines()
+makefile = open('Makefile', 'w')
+
+makefile.write("""
+all: mettle
+
+include make/Makefile.common
+include make/Makefile.mettle
+include make/Makefile.tools
+
+distclean:
+\t@rm -fr $(BUILD)
+
+clean:
+\t@rm -fr $(BUILD)/mettle
+
+""")
+
+makefile.write("all-parallel: \\\n")
+makefile.write(" \\\n".join(["\t%s.build" % a for a in arches]))
+makefile.write("\n\n")
+
+makefile.write("clean-parallel: \\\n")
+makefile.write(" \\\n".join(["\t%s.clean" % a for a in arches]))
+makefile.write("\n\n")
+
+makefile.write("distclean-parallel: \\\n")
+makefile.write(" \\\n".join(["\t%s.distclean" % a for a in arches]))
+makefile.write("\n\n")
+
+for arch in arches:
+    makefile.write("%s.build: $(ROOT)/build/tools/musl-cross/.unpacked\n" % arch)
+    makefile.write("\tmake TARGET=%s\n" % arch)
+    makefile.write("%s.clean:\n" % arch)
+    makefile.write("\tmake TARGET=%s clean\n" % arch)
+    makefile.write("%s.distclean:\n" % arch)
+    makefile.write("\tmake TARGET=%s distclean\n" % arch)
+
+makefile.close()

--- a/make-all
+++ b/make-all
@@ -1,9 +1,3 @@
 #!/bin/sh
 
-set -e
-
-for i in $(cat ARCHES); do
-	echo Building target $i
-	make TARGET=$i;
-done
-
+make all-parallel -j4


### PR DESCRIPTION
This fixes #43, adding parallel make rules for building multiple targets at once. Lightly tested on my desktop, there may still need to be some mutual exclusion running autotools on the mettle directory. I couldn't figure out how to generate the correct Makefile patterns, so I just wrote a python script to generate the Makefile instead.