### PR TITLE
Parallel and dynamic rules for building Mettle.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 all: mettle
 
 include make/Makefile.common
@@ -9,3 +10,27 @@ distclean:
 
 clean:
 	@rm -fr $(BUILD)/mettle
+
+ARCHES := $(shell cat ARCHES)
+
+# Create the individual build/clean/dist-clean rules for each arch...
+define rules_for_each_arch
+
+$(strip $(1)).build: $(ROOT)/build/tools/musl-cross/.unpacked
+	make TARGET=$(strip $(1))
+
+$(strip $(1)).clean:
+	make TARGET=$(strip $(1)) clean
+
+$(strip $(1)).distclean:
+	make TARGET=$(strip $(1)) distclean
+
+endef
+
+$(foreach a, $(ARCHES), $(eval $(call rules_for_each_arch, $(strip $(a)))))
+
+all-parallel: $(patsubst %,%.build,$(ARCHES))
+
+clean-parallel: $(patsubst %,%.clean,$(ARCHES))
+
+distclean-parallel: $(patsubst %,%.distclean,$(ARCHES))

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ git submodule init; git submodule update
 ```
 after cloning.
 
-To build the gem (currently requires linux):
+To build the gem (currently requires Linux or macOS):
 
 ```
 rake build
@@ -24,6 +24,26 @@ To completely reset your dev environment and delete all binary artifacts:
 ```
 rake mettle:ultraclean
 ```
+
+Make Targets
+------------
+
+For general development, there are a few make targets defined:
+
+Running `make` will build for the local environment. E.g. if you're on macOS,
+it will build for macOS using your native compiler and tools.
+
+`make TARGET=triple` will build for a specific host triple. See below for some
+common ones.
+
+`make clean` will clean the 'mettle' directory for the current build target
+
+`make distclean` will clean the entire build target`
+
+`make all-parallel` will build for every known target, useful with '-j' to build multiple targets at once.
+
+`make clean-parallel` and `make distclean-parallel` do similar for all targets.
+
 
 Gem API
 -------

--- a/make-all
+++ b/make-all
@@ -1,9 +1,3 @@
 #!/bin/sh
 
-set -e
-
-for i in $(cat ARCHES); do
-	echo Building target $i
-	make TARGET=$i;
-done
-
+make all-parallel -j4


### PR DESCRIPTION
Based on [PR #58](https://github.com/rapid7/mettle/pull/58), this is just a different take on fixing #43.  When `make` is invoked, the current list of target architectures is read from the ARCHES file and rules are created for doing parallel build/clean/distclean operations on them.

NOTE: I tested the make rules look and act correctly, but did not try an actual build.