### PR TITLE
Fix #64, fix process channel closing

### DIFF
--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -318,6 +318,10 @@ void channel_set_interactive(struct channel *c, bool enable)
 	c->interactive = enable;
 }
 
+bool channel_get_interactive(struct channel *c)
+{
+	return c->interactive;
+}
 
 static struct tlv_packet *channel_interact(struct tlv_handler_ctx *ctx)
 {

--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -62,6 +62,8 @@ struct channel_callbacks * channel_get_callbacks(struct channel *c);
 
 void channel_set_interactive(struct channel *c, bool enable);
 
+bool channel_get_interactive(struct channel *c);
+
 int channel_send_close_request(struct channel *c);
 
 int channel_enqueue(struct channel *c, void *buf, size_t buf_len);

--- a/mettle/src/process.c
+++ b/mettle/src/process.c
@@ -39,6 +39,7 @@ struct process {
 	process_exit_cb_t exit_cb;
 
 	void *cb_arg;
+	uint32_t channel_id;
 
 	UT_hash_handle hh;
 	pid_t pid;
@@ -54,6 +55,16 @@ extern char **environ;
 pid_t process_get_pid(struct process *process)
 {
 	return process->pid;
+}
+
+uint32_t process_get_channel_id(struct process *process)
+{
+	return process->channel_id;
+}
+
+void process_set_channel_id(struct process *process, uint32_t channel_id)
+{
+	process->channel_id = channel_id;
 }
 
 static void free_process_queue(struct ev_loop *loop, struct process_queue *pipe)
@@ -238,7 +249,7 @@ static void stdout_cb(struct ev_loop *loop, struct ev_io *w, int events)
 
 	if (read_fd_into_queue(w->fd, process->out.queue) > 0) {
 		if (process->out_cb) {
-			process->out_cb(process->out.queue, process->cb_arg);
+			process->out_cb(process, process->out.queue, process->cb_arg);
 		}
 	}
 }
@@ -249,7 +260,7 @@ static void stderr_cb(struct ev_loop *loop, struct ev_io *w, int events)
 
 	if (read_fd_into_queue(w->fd, process->err.queue) > 0) {
 		if (process->err_cb) {
-			process->err_cb(process->err.queue, process->cb_arg);
+			process->err_cb(process, process->err.queue, process->cb_arg);
 		}
 	}
 }

--- a/mettle/src/process.h
+++ b/mettle/src/process.h
@@ -13,7 +13,7 @@ void procmgr_free(struct procmgr *mgr);
 
 typedef void (*process_exit_cb_t)(struct process *, int exit_status, void *arg);
 
-typedef	void (*process_read_cb_t)(struct buffer_queue *queue, void *arg);
+typedef	void (*process_read_cb_t)(struct process *, struct buffer_queue *queue, void *arg);
 
 struct process_options {
 	const char *args;               /* Process arguments (none if not specified) */
@@ -64,5 +64,15 @@ int process_kill_by_pid(struct procmgr *mgr, pid_t pid);
  * Returns the PID of the given process
  */
 pid_t process_get_pid(struct process *p);
+
+/*
+ * Returns the channel_id of the given process
+ */
+uint32_t process_get_channel_id(struct process *process);
+
+/*
+ * Sets the channel_id of the given process
+ */
+void process_set_channel_id(struct process *process, uint32_t channel_id);
 
 #endif

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -205,7 +205,7 @@ static void process_channel_exit_cb(struct process *p, int exit_status, void *ar
 	struct channelmgr *cm = arg;
 	uint32_t channel_id = process_get_channel_id(p);
 	struct channel *c = channelmgr_channel_by_id(cm, channel_id);
-	if (c) {
+	if (c && channel_get_interactive(c)) {
 		channel_send_close_request(c);
 	}
 }


### PR DESCRIPTION
This PR contains two fixes:
One for `cmd_exec("sleep 1;echo test;sleep 1")` the UAF crash is fixed by doing channelmgr_channel_by_id to check whether the channel is still valid before sending a close_request
Another fix for ensuring the output of `cmd_exec("echo test")` is returned correctly (this may be invoking Cunninghams law).