### PR TITLE
fix alignment on armv5 and other architectures

### DIFF
--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -28,17 +28,17 @@ struct tlv_xor_header {
 	uint32_t xor_key;
 	int32_t len;
 	uint32_t type;
-};
+} __attribute__((packed));
 
 struct tlv_header {
 	int32_t len;
 	uint32_t type;
-};
+} __attribute__((packed));
 
 struct tlv_packet {
 	struct tlv_header h;
 	char buf[];
-};
+} __attribute__((packed));
 
 static uint32_t tlv_xor_key(void)
 {


### PR DESCRIPTION
Currently we fail to run on architectures that do not natively support byte-aligned memory access. On armv5, it simply does a misread when parsing TLV packets, causing a disconnect when packet sanity checks fail. On Sparc, it causes a bus error. This marks the tlv headers as needing byte access to the compiler.

