### PR TITLE
Default images to portrait orientation.

### DIFF
--- a/mettle/src/stdapi/webcam/apple_webcam.m
+++ b/mettle/src/stdapi/webcam/apple_webcam.m
@@ -91,13 +91,13 @@
       return nil;
     }
 #if TARGET_OS_IPHONE
-    CIImage *ciImage = [CIImage imageWithCVPixelBuffer:head];
+    CIImage *ciImage = [[CIImage imageWithCVPixelBuffer:head] imageByApplyingOrientation:6];
     CIContext *temporaryContext = [CIContext contextWithOptions:nil];
     CGImageRef videoImage = [temporaryContext
       createCGImage:ciImage
            fromRect:CGRectMake(0, 0,
-               CVPixelBufferGetWidth(head),
-               CVPixelBufferGetHeight(head))];
+               CVPixelBufferGetHeight(head),
+               CVPixelBufferGetWidth(head))];
     UIImage *uiImage = [[UIImage alloc] initWithCGImage:videoImage];
     NSData* frame = UIImageJPEGRepresentation(uiImage, 1.0);
     CGImageRelease(videoImage);


### PR DESCRIPTION
I've struggled to successfully retrieve the orientation info from the picture EXIF data or the device orientation from iOS itself in order to auto-adjust the image rotation to the correct orientation based on the position the target device was in while doing a webcam stream.  This fix will rotate the image to the "usual" orientation folks use the front-facing camera with, we can improve on this later.  :)

Fixes MS-2605.