### PR TITLE
add ability to fork into the background

### DIFF
--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -53,6 +53,8 @@ module MetasploitPayloads
         'u'
       when :uuid
         'U'
+      when :background
+        'b'
       when :debug
         'd'
       when :log_file

--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -57,6 +57,8 @@ module MetasploitPayloads
         'd'
       when :log_file
         'o'
+      when :background
+        'b'
       else
         fail RuntimeError, "unknown mettle option #{opt}", caller
       end

--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -10,6 +10,8 @@ end
 module MetasploitPayloads
   class Mettle
 
+    CmdlineMax = 512
+    CmdlineSig = "DEFAULT_OPTS"
     #
     # Config is a hash. Valid keys are:
     #  :uri to connect to
@@ -40,11 +42,11 @@ module MetasploitPayloads
       @config.each do |opt, val|
         cmd_line << "-#{short_opt(opt)} \"#{val}\" "
       end
-      if cmd_line.length > 264
+      if cmd_line.length > CmdlineMax
         fail RuntimeError, 'mettle argument list too big', caller
       end
 
-      cmd_line + "\x00" * (264 - cmd_line.length)
+      cmd_line + "\x00" * (CmdlineMax - cmd_line.length)
     end
 
     def short_opt(opt)
@@ -66,7 +68,7 @@ module MetasploitPayloads
 
     def add_args(bin, params)
       if params[8] != "\x00"
-        bin.sub('DEFAULT_OPTS' +  ' ' * 252, params)
+        bin.sub(CmdlineSig +  ' ' * (CmdlineMax - CmdlineSig.length), params)
       else
         bin
       end

--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -49,18 +49,16 @@ module MetasploitPayloads
 
     def short_opt(opt)
       case opt
-      when :uri
-        'u'
-      when :uuid
-        'U'
       when :background
         'b'
       when :debug
         'd'
       when :log_file
         'o'
-      when :background
-        'b'
+      when :uri
+        'u'
+      when :uuid
+        'U'
       else
         fail RuntimeError, "unknown mettle option #{opt}", caller
       end

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -26,6 +26,7 @@ libmettle_la_SOURCES += http_client.c
 libmettle_la_SOURCES += log.c
 libmettle_la_SOURCES += network_client.c
 libmettle_la_SOURCES += network_server.c
+libmettle_la_SOURCES += service.c
 libmettle_la_SOURCES += tlv.c
 libmettle_la_SOURCES += stdapi/stdapi.c
 libmettle_la_SOURCES += stdapi/webcam/webcam.c

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -15,6 +15,7 @@
 #include "argv_split.h"
 #include "log.h"
 #include "mettle.h"
+#include "service.h"
 
 static void usage(const char *name)
 {
@@ -24,6 +25,7 @@ static void usage(const char *name)
 	printf("  -U, --uuid [uuid] set the UUID (base64)\n");
 	printf("  -d, --debug       enable debug output\n");
 	printf("  -o, --out [file]  write debug output to a file\n");
+	printf("  -b, --background  start as a background service\n");
 	printf("\n");
 	exit(1);
 }
@@ -49,11 +51,13 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 		{"out", required_argument, NULL, 'o'},
 		{"uri", required_argument, NULL, 'u'},
 		{"uuid", required_argument, NULL, 'U'},
+		{"background", no_argument, NULL, 'b'},
 		{ 0, 0, NULL, 0 }
 	};
-	const char *short_options = "hu:U:do:";
+	const char *short_options = "hu:U:do:b";
 	const char *out = NULL;
 	bool debug = false;
+	bool background = false;
 	int log_level = 0;
 
 	/*
@@ -73,6 +77,9 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 			debug = true;
 			log_set_level(++log_level);
 			break;
+		case 'b':
+			background = true;
+			break;
 		case 'o':
 			out = optarg;
 			break;
@@ -84,6 +91,10 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 
 	if (debug) {
 		start_logger(out);
+	}
+
+	if (background) {
+		start_service();
 	}
 
 	return 0;

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -127,6 +127,10 @@ void parse_default_args(struct mettle *m)
 		"                                                               "
 		"                                                               "
 		"                                                               "
+		"                                                               "
+		"                                                               "
+		"                                                               "
+		"                                                               "
 		"                                                               ";
 
 	if (strncasecmp(default_opts, "default_opts", strlen("default_opts"))) {

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -20,12 +20,12 @@
 static void usage(const char *name)
 {
 	printf("Usage: %s [options]\n", name);
-	printf("  -h, --help        display help\n");
-	printf("  -u, --uri [uri]   add connection URI\n");
-	printf("  -U, --uuid [uuid] set the UUID (base64)\n");
-	printf("  -d, --debug       enable debug output\n");
-	printf("  -o, --out [file]  write debug output to a file\n");
-	printf("  -b, --background  start as a background service\n");
+	printf("  -h, --help             display help\n");
+	printf("  -u, --uri <uri>        add connection URI\n");
+	printf("  -U, --uuid <uuid>      set the UUID (base64)\n");
+	printf("  -d, --debug [level]    enable debug output\n");
+	printf("  -o, --out <file>       write debug output to a file\n");
+	printf("  -b, --background [0|1] start as a background service\n");
 	printf("\n");
 	exit(1);
 }
@@ -47,14 +47,14 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 	int index = 0;
 
 	struct option options[] = {
-		{"debug", no_argument, NULL, 'd'},
+		{"debug", optional_argument, NULL, 'd'},
 		{"out", required_argument, NULL, 'o'},
 		{"uri", required_argument, NULL, 'u'},
 		{"uuid", required_argument, NULL, 'U'},
-		{"background", no_argument, NULL, 'b'},
+		{"background", optional_argument, NULL, 'b'},
 		{ 0, 0, NULL, 0 }
 	};
-	const char *short_options = "hu:U:do:b";
+	const char *short_options = "hu:U:d::o:b::";
 	const char *out = NULL;
 	bool debug = false;
 	bool background = false;
@@ -74,11 +74,32 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 			mettle_set_uuid_base64(m, optarg);
 			break;
 		case 'd':
-			debug = true;
-			log_set_level(++log_level);
+			if (optarg) {
+				const char *errstr = NULL;
+				int val = strtonum(optarg, 0, 3, &errstr);
+				if (errstr != NULL) {
+					fprintf(stderr, "invalid debug level '%s': %s\n", optarg, errstr);
+					return -1;
+				}
+				log_level = val;
+			} else {
+				log_level++;
+			}
+			log_set_level(log_level);
+			debug = (log_level > 0);
 			break;
 		case 'b':
-			background = true;
+			if (optarg) {
+				const char *errstr = NULL;
+				int val = strtonum(optarg, 0, 1, &errstr);
+				if (errstr != NULL) {
+					fprintf(stderr, "invalid background setting '%s': %s", optarg, errstr);
+					return -1;
+				}
+				background = val == 1;
+			} else {
+				background = true;
+			}
 			break;
 		case 'o':
 			out = optarg;
@@ -150,7 +171,9 @@ int main(int argc, char * argv[])
 		parse_default_args(m);
 	} else {
 		parse_default_args(m);
-		parse_cmdline(argc, argv, m);
+		if (parse_cmdline(argc, argv, m)) {
+			return -1;
+		}
 	}
 
 	/*

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -124,14 +124,16 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 void parse_default_args(struct mettle *m)
 {
 	static char default_opts[] = "DEFAULT_OPTS"
-		"                                                               "
-		"                                                               "
-		"                                                               "
-		"                                                               "
-		"                                                               "
-		"                                                               "
-		"                                                               "
-		"                                                               ";
+		"                                                  "
+		"                                                  "
+		"                                                  "
+		"                                                  "
+		"                                                  "
+		"                                                  "
+		"                                                  "
+		"                                                  "
+		"                                                  "
+		"                                                  ";
 
 	if (strncasecmp(default_opts, "default_opts", strlen("default_opts"))) {
 		size_t argc = 0;

--- a/mettle/src/service.c
+++ b/mettle/src/service.c
@@ -1,0 +1,72 @@
+/**
+ * @brief Service Management Functions
+ * @file service.c
+ */
+
+#include "service.h"
+
+#ifdef _WIN32
+
+int start_service(void)
+{}
+
+#else
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+#include <string.h>
+#include "log.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+int start_service(void)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		log_error("could not fork: %s", strerror(errno));
+		return -1;
+	} else if (pid > 0) {
+		exit(EXIT_SUCCESS);
+	}
+
+	/*
+	 * Prevent open(1) from allocating controling TTYs
+	 */
+	pid_t sid = setsid();
+	if (sid < 0) {
+		log_error("could not get new SID: %s", strerror(errno));
+		return -1;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		log_error("could not fork: %s", strerror(errno));
+		return -1;
+	} else if (pid > 0) {
+		exit(EXIT_SUCCESS);
+	}
+
+	/*
+	 * Update standard file descriptors
+	 */
+	close(STDIN_FILENO);
+	close(STDOUT_FILENO);
+	close(STDERR_FILENO);
+	if (open("/dev/null", O_RDONLY) == -1) {
+		log_error("failed to reopen stdin: %s", strerror(errno));
+	}
+	if (open("/dev/null", O_RDONLY) == -1) {
+		log_error("failed to reopen stdout: %s", strerror(errno));
+	}
+	if (open("/dev/null", O_RDONLY) == -1) {
+		log_error("failed to reopen stderr: %s", strerror(errno));
+	}
+
+	return 0;
+}
+
+#endif

--- a/mettle/src/service.h
+++ b/mettle/src/service.h
@@ -1,0 +1,6 @@
+#ifndef _METTLE_SERVICE_H_
+#define _METTLE_SERVICE_H_
+
+int start_service(void);
+
+#endif


### PR DESCRIPTION
This adds a '-b' flag which tells mettle to start in the background. Adding corresponding Framework PR to make this configurable like it is with Python meterpreter.