### PR TITLE
WiP feature for service and persistence management

### DIFF
--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -138,22 +138,22 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 	}
 
 	if (background) {
-		char *cmd, *new_cmd;
-		if (asprintf(&cmd, "%s -d %u", argv[0], log_level) == -1) {
+		char *args, *new_args;
+		if (asprintf(&args, "%s -d %u", argv[0], log_level) == -1) {
 			return -1;
 		}
 		optind = 1;
 		while ((c = getopt_long(argc, argv, short_options, options, &index)) != -1) {
 			if (c == 'u' || c == 'U' || c == 'o') {
-				if (asprintf(&new_cmd, "%s -u %s", cmd, optarg) == -1) {
+				if (asprintf(&new_args, "%s -%c %s", args, c, optarg) == -1) {
 					return -1;
 				}
-				free(cmd);
-				cmd = new_cmd;
+				free(args);
+				args = new_args;
 			}
 		}
-		start_service(name, cmd, persist);
-		free(cmd);
+		start_service(name, argv[0], args, persist);
+		free(args);
 	}
 
 	return 0;

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -26,6 +26,8 @@ static void usage(const char *name)
 	printf("  -d, --debug [level]    enable debug output\n");
 	printf("  -o, --out <file>       write debug output to a file\n");
 	printf("  -b, --background [0|1] start as a background service\n");
+	printf("  -p, --persist [none|install|uninstall] manage persistence\n");
+	printf("  -n, --name <name>      name to start as\n");
 	printf("\n");
 	exit(1);
 }
@@ -53,12 +55,16 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 		{"uuid", required_argument, NULL, 'U'},
 		{"session-guid", required_argument, NULL, 'G'},
 		{"background", optional_argument, NULL, 'b'},
+		{"persist", required_argument, NULL, 'p'},
+		{"name", required_argument, NULL, 'n'},
 		{ 0, 0, NULL, 0 }
 	};
-	const char *short_options = "hu:U:G:d::o:b::";
+	const char *short_options = "hu:U:G:d::o:b::p:n:";
 	const char *out = NULL;
+	char *name = strdup("service");
 	bool debug = false;
 	bool background = false;
+	enum persist_type persist = persist_none;
 	int log_level = 0;
 
 	/*
@@ -76,6 +82,19 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 			break;
 		case 'G':
 			mettle_set_session_guid_base64(m, optarg);
+			break;
+		case 'n':
+			free(name);
+			name = strdup(optarg);
+			break;
+		case 'p':
+			if (strcmp("install", optarg) == 0) {
+				persist = persist_install;
+			} else if (strcmp("uninstall", optarg) == 0) {
+				persist = persist_uninstall;
+			} else {
+				persist = persist_none;
+			}
 			break;
 		case 'd':
 			if (optarg) {
@@ -133,7 +152,7 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 				cmd = new_cmd;
 			}
 		}
-		start_service(cmd);
+		start_service(name, cmd, persist);
 		free(cmd);
 	}
 

--- a/mettle/src/service.c
+++ b/mettle/src/service.c
@@ -62,7 +62,8 @@ int fork_service(void)
 	return 0;
 }
 
-int start_service(const char *name, const char *cmd, enum persist_type persist)
+int start_service(const char *name, const char *path, const char *args,
+	enum persist_type persist)
 {
 	switch (persist) {
 		case persist_none:

--- a/mettle/src/service.c
+++ b/mettle/src/service.c
@@ -16,7 +16,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-int start_service(const char *cmd)
+int fork_service(void)
 {
 	pid_t pid = fork();
 	if (pid < 0) {
@@ -60,4 +60,16 @@ int start_service(const char *cmd)
 	}
 
 	return 0;
+}
+
+int start_service(const char *name, const char *cmd, enum persist_type persist)
+{
+	switch (persist) {
+		case persist_none:
+			return fork_service();
+		case persist_install:
+		case persist_uninstall:
+			return -1;
+	}
+	return -1;
 }

--- a/mettle/src/service.h
+++ b/mettle/src/service.h
@@ -1,6 +1,12 @@
 #ifndef _METTLE_SERVICE_H_
 #define _METTLE_SERVICE_H_
 
-int start_service(const char *cmd);
+enum persist_type {
+	persist_none,
+	persist_install,
+	persist_uninstall
+};
+
+int start_service(const char *name, const char *cmd, enum persist_type persist);
 
 #endif

--- a/mettle/src/service.h
+++ b/mettle/src/service.h
@@ -7,6 +7,7 @@ enum persist_type {
 	persist_uninstall
 };
 
-int start_service(const char *name, const char *cmd, enum persist_type persist);
+int start_service(const char *name, const char *path, const char *args,
+	enum persist_type persist);
 
 #endif

--- a/mettle/src/service_win.c
+++ b/mettle/src/service_win.c
@@ -10,10 +10,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-int start_service(const char *cmd)
+int background_service(const char *cmd)
 {
 	char *cmdline;
-	asprintf(&cmdline, "cmd.exe \"start /b %s\"", cmd);
+	asprintf(&cmdline, "cmd.exe /q /c \"start /b %s\"", cmd);
 	system(cmdline);
 	exit(0);
 	return 0;
@@ -31,4 +31,16 @@ void set_service_name(const char *name)
 	}
 	service_name = base;
 	free(tmp);
+}
+
+int start_service(const char *name, const char *cmd, enum persist_type persist)
+{
+	switch (persist) {
+		case persist_none:
+			return background_service(cmd);
+		case persist_install:
+		case persist_uninstall:
+			return -1;
+	}
+	return -1;
 }

--- a/mettle/src/service_win.c
+++ b/mettle/src/service_win.c
@@ -9,16 +9,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "log.h"
 
-int background_service(const char *cmd)
+int background_service(const char *path, const char *args)
 {
 	char *cmdline;
-	asprintf(&cmdline, "cmd.exe /q /c \"start /b %s\"", cmd);
+	asprintf(&cmdline, "cmd.exe /q /c \"start /b %s %s\"", path, args);
 	system(cmdline);
 	exit(0);
 	return 0;
 }
 
+/*
 static char *service_name = NULL;
 
 void set_service_name(const char *name)
@@ -33,11 +35,24 @@ void set_service_name(const char *name)
 	free(tmp);
 }
 
-int start_service(const char *name, const char *cmd, enum persist_type persist)
+int install_service(const char *name, const char *display_name)
+{
+	int rc = -1;
+	SC_HANDLE svc = NULL, scm = NULL;
+
+	SC_HANDLE scm = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERICE);
+	if (scm == NULL) {
+		log_error("could not open SCM");
+		return -1;
+	}
+*/
+
+int start_service(const char *name, const char *path, const char *args,
+	enum persist_type persist)
 {
 	switch (persist) {
 		case persist_none:
-			return background_service(cmd);
+			return background_service(path, args);
 		case persist_install:
 		case persist_uninstall:
 			return -1;


### PR DESCRIPTION
In addition to fixing a compile error on win32, this adds a more general way to handle persistence and backgrounding on win32.

Not everything is implemented yet, but the idea is to make it easy when you have the payload on a box to enable persistence via service, cron, or whatever makes sense without needing a post module.

This also fixes some build errors when cross-compiling win32 from macOS.