### PR TITLE
Add support for session GUIDs in mettle

### DIFF
--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -61,6 +61,8 @@ module MetasploitPayloads
         'u'
       when :uuid
         'U'
+      when :session_guid
+        'G'
       else
         fail RuntimeError, "unknown mettle option #{opt}", caller
       end

--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -60,6 +60,35 @@ static struct tlv_packet *core_shutdown(struct tlv_handler_ctx *ctx)
 	return p;
 }
 
+static struct tlv_packet *core_get_session_guid(struct tlv_handler_ctx *ctx)
+{
+	size_t session_guid_len;
+	struct mettle *m = ctx->arg;
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+	const char *session_guid = tlv_dispatcher_get_session_guid(td, &session_guid_len);
+
+	if (session_guid && session_guid_len) {
+	       struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+	       return tlv_packet_add_raw(p, TLV_TYPE_SESSION_GUID, session_guid, session_guid_len);
+	}
+
+	return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
+}
+
+static struct tlv_packet *core_set_session_guid(struct tlv_handler_ctx *ctx)
+{
+	size_t guid_len = 0;
+	struct mettle *m = ctx->arg;
+	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
+	char *guid = tlv_packet_get_raw(ctx->req, TLV_TYPE_SESSION_GUID, &guid_len);
+
+	if (guid && guid_len) {
+		tlv_dispatcher_set_session_guid(td, guid, guid_len);
+	}
+
+	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
 static struct tlv_packet *core_machine_id(struct tlv_handler_ctx *ctx)
 {
 	struct mettle *m = ctx->arg;
@@ -106,5 +135,7 @@ void tlv_register_coreapi(struct mettle *m)
 	tlv_dispatcher_add_handler(td, "core_machine_id", core_machine_id, m);
 	tlv_dispatcher_add_handler(td, "core_set_uuid", core_set_uuid, m);
 	tlv_dispatcher_add_handler(td, "core_uuid", core_uuid, m);
+	tlv_dispatcher_add_handler(td, "core_get_session_guid", core_get_session_guid, m);
+	tlv_dispatcher_add_handler(td, "core_set_session_guid", core_set_session_guid, m);
 	tlv_dispatcher_add_handler(td, "core_shutdown", core_shutdown, m);
 }

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -51,10 +51,11 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 		{"out", required_argument, NULL, 'o'},
 		{"uri", required_argument, NULL, 'u'},
 		{"uuid", required_argument, NULL, 'U'},
+		{"session-guid", required_argument, NULL, 'G'},
 		{"background", optional_argument, NULL, 'b'},
 		{ 0, 0, NULL, 0 }
 	};
-	const char *short_options = "hu:U:d::o:b::";
+	const char *short_options = "hu:U:G:d::o:b::";
 	const char *out = NULL;
 	bool debug = false;
 	bool background = false;
@@ -72,6 +73,9 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 			break;
 		case 'U':
 			mettle_set_uuid_base64(m, optarg);
+			break;
+		case 'G':
+			mettle_set_session_guid_base64(m, optarg);
 			break;
 		case 'd':
 			if (optarg) {

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -111,6 +111,17 @@ int mettle_set_uuid_base64(struct mettle *m, char *uuid_b64)
 	return 0;
 }
 
+int mettle_set_session_guid_base64(struct mettle *m, char *guid_b64)
+{
+	char *guid = calloc(1, strlen(guid_b64));
+	if (guid == NULL)
+		return -1;
+	int guid_len = base64decode(guid, guid_b64, strlen(guid_b64));
+	tlv_dispatcher_set_session_guid(m->td, guid, guid_len);
+	free(guid);
+	return 0;
+}
+
 struct tlv_dispatcher *mettle_get_tlv_dispatcher(struct mettle *m)
 {
 	return m->td;

--- a/mettle/src/mettle.h
+++ b/mettle/src/mettle.h
@@ -23,6 +23,8 @@ const char *mettle_get_machine_id(struct mettle *m);
 
 int mettle_set_uuid_base64(struct mettle *m, char *uuid_b64);
 
+int mettle_set_session_guid_base64(struct mettle *m, char *uuid_b64);
+
 sigar_t *mettle_get_sigar(struct mettle *m);
 
 struct ev_loop * mettle_get_loop(struct mettle *m);

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -397,6 +397,9 @@ struct tlv_dispatcher {
 
 	char *uuid;
 	size_t uuid_len;
+
+	char *session_guid;
+	size_t session_guid_len;
 };
 
 struct tlv_packet *tlv_packet_add_uuid(struct tlv_packet *p, struct tlv_dispatcher *td)
@@ -665,6 +668,26 @@ const char *tlv_dispatcher_get_uuid(struct tlv_dispatcher *td, size_t *len)
 {
 	*len = td->uuid_len;
 	return td->uuid;
+}
+
+const char *tlv_dispatcher_get_session_guid(struct tlv_dispatcher *td, size_t *len)
+{
+	*len = td->session_guid_len;
+	return td->session_guid;
+}
+
+int tlv_dispatcher_set_session_guid(struct tlv_dispatcher *td, char *guid, size_t len)
+{
+	free(td->session_guid);
+	td->session_guid_len = 0;
+
+	td->session_guid = malloc(len);
+	if (td->session_guid == NULL)
+		return -1;
+
+	td->session_guid_len = len;
+	memcpy(td->session_guid, guid, len);
+	return 0;
 }
 
 void tlv_dispatcher_free(struct tlv_dispatcher *td)

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -138,6 +138,9 @@ const char *tlv_dispatcher_get_uuid(struct tlv_dispatcher *td, size_t *len);
 
 int tlv_dispatcher_set_uuid(struct tlv_dispatcher *td, char *uuid, size_t len);
 
+const char *tlv_dispatcher_get_session_guid(struct tlv_dispatcher *td, size_t *len);
+int tlv_dispatcher_set_session_guid(struct tlv_dispatcher *td, char *uuid, size_t len);
+
 void tlv_dispatcher_free(struct tlv_dispatcher *td);
 
 struct mettle;

--- a/mettle/src/tlv_types.h
+++ b/mettle/src/tlv_types.h
@@ -94,6 +94,7 @@
 
 #define TLV_TYPE_MACHINE_ID            (TLV_META_TYPE_STRING  | 460)
 #define TLV_TYPE_UUID                  (TLV_META_TYPE_RAW     | 461)
+#define TLV_TYPE_SESSION_GUID          (TLV_META_TYPE_RAW     | 462)
 
 #define TLV_TYPE_CIPHER_NAME           (TLV_META_TYPE_STRING  | 500)
 #define TLV_TYPE_CIPHER_PARAMETERS     (TLV_META_TYPE_GROUP   | 501)


### PR DESCRIPTION
This is the associated payloads PR that goes with the MSF PR located here: https://github.com/rapid7/metasploit-framework/pull/8523

Full detail and motivation for this code change can be found in the MSF PR description.