### PR TITLE
Remove references to cipher stuff

### DIFF
--- a/mettle/src/tlv_types.h
+++ b/mettle/src/tlv_types.h
@@ -96,9 +96,6 @@
 #define TLV_TYPE_UUID                  (TLV_META_TYPE_RAW     | 461)
 #define TLV_TYPE_SESSION_GUID          (TLV_META_TYPE_RAW     | 462)
 
-#define TLV_TYPE_CIPHER_NAME           (TLV_META_TYPE_STRING  | 500)
-#define TLV_TYPE_CIPHER_PARAMETERS     (TLV_META_TYPE_GROUP   | 501)
-
 /*
  * General
  */


### PR DESCRIPTION
Remove references to the CIPHER TLVs as they're not used.

## Verification

Doesn't really need any, just make sure it builds and sessions still work.

Associated PRs:

* Meterpreter: https://github.com/rapid7/metasploit-payloads/pull/207
* MSF: https://github.com/rapid7/metasploit-framework/pull/8584