### PR TITLE
use TARGET_OS_IPHONE available in 10.8 for configure test

### DIFF
--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -22,7 +22,7 @@ case $host_os in
 		AC_SUBST([PLATFORM_LDADD], ['-framework CoreMedia -framework QuartzCore -framework AVFoundation -framework ImageIO'])
 		AC_EGREP_CPP(yes,
 			[#import <TargetConditionals.h>
-			 #if TARGET_OS_OSX
+			 #if !TARGET_OS_IPHONE
 			 yes
 			 #endif
 			],


### PR DESCRIPTION
use a constant already defined 10.8 for testing build env