### PR TITLE
fix apple webcam_snap when index is out of bounds

### DIFF
--- a/mettle/src/stdapi/webcam/apple_webcam.m
+++ b/mettle/src/stdapi/webcam/apple_webcam.m
@@ -58,7 +58,12 @@ int count;
   session.sessionPreset = AVCaptureSessionPresetMedium;
 
   NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
-  AVCaptureDevice *device = devices[deviceIndex - 1];
+  int index = deviceIndex - 1;
+  if (index < 0 || index >= [devices count]) {
+    return false;
+  }
+
+  AVCaptureDevice *device = devices[index];
 
   NSError* error = nil;
   AVCaptureDeviceInput* input =


### PR DESCRIPTION
This fixes a crash on OSX from the command:
`webcam_snap -i 123` 