### PR TITLE
Crypttlv packet parsing updates

### DIFF
--- a/make/Makefile.curl
+++ b/make/Makefile.curl
@@ -6,7 +6,6 @@ LIBCURL_OPTS =
 
 ifneq (,$(findstring darwin,$(BUILD)))
     LIBCURL_OPTS += --with-darwinssl
-    LIBCURL_ENV += MACOSX_DEPLOYMENT_TARGET="10.8"
 else
     ifneq (,$(findstring mingw,$(BUILD)))
         LIBCURL_OPTS += --with-ssl --with-winssl

--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -23,9 +23,11 @@ ifneq (,$(findstring darwin,$(BUILD)))
 else
     ifneq (,$(findstring mingw,$(BUILD)))
     else
-        METTLE_TARGETS += $(BUILD)/bin/mettle.bin
-        METTLE_DEPS += $(BUILD)/lib/libmbedtls.a
-        METTLE_OPTS += --enable-staticpie
+        ifneq "$(TARGET)" "native"
+            METTLE_TARGETS += $(BUILD)/bin/mettle.bin
+            METTLE_DEPS += $(BUILD)/lib/libmbedtls.a
+            METTLE_OPTS += --enable-staticpie
+        endif
     endif
 endif
 

--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -41,17 +41,15 @@ $(BUILD)/mettle/Makefile: build/tools $(ROOT)/mettle/configure \
 	@cd $(BUILD)/mettle; \
 		$(ENV) $(ROOT)/mettle/$(CONFIGURE) $(METTLE_OPTS) $(LOGBUILD)
 
-$(BUILD)/mettle.built: $(BUILD)/bin/mettle
-
-$(BUILD)/bin/mettle: $(BUILD)/mettle/Makefile
+$(BUILD)/bin/mettle.built: $(BUILD)/mettle/Makefile
 	@echo "Building mettle for $(TARGET)"
 	@cd $(BUILD)/mettle; \
 		$(MAKE_INSTALL) $(LOGBUILD)
 
-$(BUILD)/bin/mettle.bin: $(BUILD)/bin/mettle
+$(BUILD)/bin/mettle.bin: $(BUILD)/bin/mettle.built
 	$(ELF2BIN) $(BUILD)/bin/mettle $(BUILD)/bin/mettle.bin
 
-mettle: $(BUILD)/mettle.built $(METTLE_TARGETS)
+mettle: $(BUILD)/bin/mettle.built $(METTLE_TARGETS)
 
 DATADIR:=../metasploit-framework/data
 METTLEDIR:=$(DATADIR)/mettle

--- a/mettle/src/c2_tcp.c
+++ b/mettle/src/c2_tcp.c
@@ -22,7 +22,7 @@ static void tcp_read_cb(struct bufferev *be, void *arg)
 	struct tcp_ctx *ctx = c2_transport_get_ctx(t);
 	if (ctx->first_packet) {
 		struct buffer_queue *q = bufferev_rx_queue(be);
-		if (tlv_have_sync_packet(q, "core_machine_id")) {
+		if (tlv_found_first_packet(q)) {
 			ctx->first_packet = 0;
 		} else {
 			return;

--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -62,17 +62,12 @@ static struct tlv_packet *core_shutdown(struct tlv_handler_ctx *ctx)
 
 static struct tlv_packet *core_get_session_guid(struct tlv_handler_ctx *ctx)
 {
-	size_t session_guid_len;
 	struct mettle *m = ctx->arg;
 	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
-	const char *session_guid = tlv_dispatcher_get_session_guid(td, &session_guid_len);
+	const char *session_guid = tlv_dispatcher_get_session_guid(td);
 
-	if (session_guid && session_guid_len) {
-	       struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
-	       return tlv_packet_add_raw(p, TLV_TYPE_SESSION_GUID, session_guid, session_guid_len);
-	}
-
-	return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
+	struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+	return tlv_packet_add_raw(p, TLV_TYPE_SESSION_GUID, session_guid, SESSION_GUID_LEN);
 }
 
 static struct tlv_packet *core_set_session_guid(struct tlv_handler_ctx *ctx)
@@ -82,10 +77,10 @@ static struct tlv_packet *core_set_session_guid(struct tlv_handler_ctx *ctx)
 	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
 	char *guid = tlv_packet_get_raw(ctx->req, TLV_TYPE_SESSION_GUID, &guid_len);
 
-	if (guid && guid_len) {
-		tlv_dispatcher_set_session_guid(td, guid, guid_len);
-	}
+	if (!guid || guid_len != SESSION_GUID_LEN)
+		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 
+	tlv_dispatcher_set_session_guid(td, guid);
 	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 }
 

--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -127,6 +127,11 @@ static struct tlv_packet *core_uuid(struct tlv_handler_ctx *ctx)
 	return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 }
 
+static struct tlv_packet *negotiate_tlv_encryption(struct tlv_handler_ctx *ctx)
+{
+	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
 void tlv_register_coreapi(struct mettle *m)
 {
 	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
@@ -137,5 +142,6 @@ void tlv_register_coreapi(struct mettle *m)
 	tlv_dispatcher_add_handler(td, "core_uuid", core_uuid, m);
 	tlv_dispatcher_add_handler(td, "core_get_session_guid", core_get_session_guid, m);
 	tlv_dispatcher_add_handler(td, "core_set_session_guid", core_set_session_guid, m);
+	tlv_dispatcher_add_handler(td, "core_negotiate_tlv_encryption", negotiate_tlv_encryption, m);
 	tlv_dispatcher_add_handler(td, "core_shutdown", core_shutdown, m);
 }

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -120,11 +120,15 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 
 	if (background) {
 		char *cmd, *new_cmd;
-		asprintf(&cmd, "%s -d %u", argv[0], log_level);
+		if (asprintf(&cmd, "%s -d %u", argv[0], log_level) == -1) {
+			return -1;
+		}
 		optind = 1;
 		while ((c = getopt_long(argc, argv, short_options, options, &index)) != -1) {
 			if (c == 'u' || c == 'U' || c == 'o') {
-				asprintf(&new_cmd, "%s -u %s", cmd, optarg);
+				if (asprintf(&new_cmd, "%s -u %s", cmd, optarg) == -1) {
+					return -1;
+				}
 				free(cmd);
 				cmd = new_cmd;
 			}

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -117,7 +117,9 @@ int mettle_set_session_guid_base64(struct mettle *m, char *guid_b64)
 	if (guid == NULL)
 		return -1;
 	int guid_len = base64decode(guid, guid_b64, strlen(guid_b64));
-	tlv_dispatcher_set_session_guid(m->td, guid, guid_len);
+	if (guid_len != SESSION_GUID_LEN)
+		return -1;
+	tlv_dispatcher_set_session_guid(m->td, guid);
 	free(guid);
 	return 0;
 }

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -138,8 +138,9 @@ const char *tlv_dispatcher_get_uuid(struct tlv_dispatcher *td, size_t *len);
 
 int tlv_dispatcher_set_uuid(struct tlv_dispatcher *td, char *uuid, size_t len);
 
-const char *tlv_dispatcher_get_session_guid(struct tlv_dispatcher *td, size_t *len);
-int tlv_dispatcher_set_session_guid(struct tlv_dispatcher *td, char *uuid, size_t len);
+#define SESSION_GUID_LEN 16
+const char *tlv_dispatcher_get_session_guid(struct tlv_dispatcher *td);
+int tlv_dispatcher_set_session_guid(struct tlv_dispatcher *td, char *uuid);
 
 void tlv_dispatcher_free(struct tlv_dispatcher *td);
 

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -23,7 +23,7 @@ struct tlv_packet;
 
 struct tlv_packet *tlv_packet_new(uint32_t type, int initial_len);
 
-bool tlv_have_sync_packet(struct buffer_queue *q, const char *method);
+bool tlv_found_first_packet(struct buffer_queue *q);
 
 struct tlv_packet * tlv_packet_read_buffer_queue(struct buffer_queue *q);
 

--- a/mettle/src/tlv_types.h
+++ b/mettle/src/tlv_types.h
@@ -96,6 +96,11 @@
 #define TLV_TYPE_UUID                  (TLV_META_TYPE_RAW     | 461)
 #define TLV_TYPE_SESSION_GUID          (TLV_META_TYPE_RAW     | 462)
 
+#define TLV_TYPE_RSA_PUB_KEY           (TLV_META_TYPE_STRING  | 550)
+#define TLV_TYPE_SYM_KEY_TYPE          (TLV_META_TYPE_UINT    | 551)
+#define TLV_TYPE_SYM_KEY               (TLV_META_TYPE_RAW     | 552)
+#define TLV_TYPE_ENC_SYM_KEY           (TLV_META_TYPE_RAW     | 553)
+
 /*
  * General
  */


### PR DESCRIPTION
This just does the minimal changes required to support the new crypttlv packet parsing format. Verify that it works with staged and stageless on at least a couple of architectures.