### PR TITLE
HTTP transport fixes

### DIFF
--- a/mettle/src/buffer_queue.c
+++ b/mettle/src/buffer_queue.c
@@ -99,6 +99,7 @@ void * buffer_queue_remove_msg(struct buffer_queue *q, size_t *len)
 		LL_DELETE(q->head, buf);
 		data = buf->data;
 		*len = buf->len;
+		q->bytes -= buf->len;
 		free(buf);
 	}
 	return data;

--- a/mettle/src/c2.c
+++ b/mettle/src/c2.c
@@ -196,6 +196,11 @@ ssize_t c2_write(struct c2 *c2, void *buf, size_t buflen)
 	return len;
 }
 
+struct c2_transport* c2_get_current_transport(struct c2 *c2)
+{
+	return c2->curr_transport;
+}
+
 void c2_transport_ingress_buf(struct c2_transport *t, void *buf, size_t buflen)
 {
 	if (buffer_queue_add(t->c2->ingress, buf, buflen) == 0) {

--- a/mettle/src/c2.h
+++ b/mettle/src/c2.h
@@ -13,13 +13,13 @@ struct c2;
 
 struct c2 * c2_new(struct ev_loop *loop);
 
-int c2_add_transport_uri(struct c2 *nc, const char *uri);
+int c2_add_transport_uri(struct c2 *c2, const char *uri);
 
-int c2_start(struct c2 *nc);
+int c2_start(struct c2 *c2);
 
-int c2_close(struct c2 *nc);
+int c2_close(struct c2 *c2);
 
-void c2_free(struct c2 *nc);
+void c2_free(struct c2 *c2);
 
 #define C2_REACHABLE 0x01
 
@@ -32,9 +32,9 @@ void c2_set_cbs(struct c2 *be,
 	c2_event_cb event_cb,
 	void *cb_arg);
 
-ssize_t c2_read(struct c2 *nc, void *buf, size_t buflen);
+ssize_t c2_read(struct c2 *c2, void *buf, size_t buflen);
 
-ssize_t c2_write(struct c2 *nc, void *buf, size_t buflen);
+ssize_t c2_write(struct c2 *c2, void *buf, size_t buflen);
 
 struct buffer_queue* c2_ingress_queue(struct c2 *c2);
 
@@ -55,6 +55,8 @@ struct c2_transport_cbs {
 
 int c2_register_transport_type(struct c2 *c2, const char *proto,
 	struct c2_transport_cbs *cbs);
+
+struct c2_transport* c2_get_current_transport(struct c2 *c2);
 
 const char * c2_transport_uri(struct c2_transport *t);
 const char * c2_transport_dest(struct c2_transport *t);

--- a/mettle/src/c2_http.c
+++ b/mettle/src/c2_http.c
@@ -22,7 +22,6 @@ struct http_ctx {
 	struct http_request_opts opts;
 	struct buffer_queue *egress;
 	int first_packet;
-	int in_flight;
 	int running;
 };
 
@@ -72,7 +71,10 @@ static void http_poll_cb(struct http_conn *conn, void *arg)
 			got_command = true;
 		} else {
 			size_t len;
-			if (buffer_queue_len(q)) {
+			if (buffer_queue_len(ctx->egress) > 0) {
+				got_command = true;
+			}
+			if (buffer_queue_len(q) > 0) {
 				got_command = true;
 				c2_transport_ingress_queue(ctx->t, q);
 			}
@@ -80,34 +82,36 @@ static void http_poll_cb(struct http_conn *conn, void *arg)
 	}
 
 	if (got_command) {
-		ctx->poll_timer.repeat = 0.01;
+		ctx->poll_timer.repeat = 0.1;
 	} else {
-		if (ctx->poll_timer.repeat < 0.1) {
-			ctx->poll_timer.repeat = 0.1;
-		} else if (ctx->poll_timer.repeat < 5.0) {
-			ctx->poll_timer.repeat += 0.1;
+		if (ctx->poll_timer.repeat < 6.4) {
+			ctx->poll_timer.repeat *= 2;
 		}
 	}
-
-	ctx->in_flight = 0;
 }
 
 static void http_poll_timer_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 {
 	struct http_ctx *ctx = w->data;
-	if (!ctx->in_flight) {
-		ctx->in_flight = 1;
-		if (buffer_queue_len(ctx->egress) > 0) {
-			ctx->data.content_len = buffer_queue_remove_all(ctx->egress,
-					&ctx->data.content);
-			http_request(ctx->uri, http_request_post, http_poll_cb, ctx,
-					&ctx->data, &ctx->opts);
-			ctx->data.content_len = 0;
-			ctx->data.content = NULL;
-		} else {
-			http_request(ctx->uri, http_request_get, http_poll_cb, ctx,
-					&ctx->data, &ctx->opts);
-		}
+	bool sent = false;
+
+	while (buffer_queue_len(ctx->egress) > 0) {
+		/*
+		 * Metasploit's HTTP handler cannot handle multiple queued messages, send these individually for now
+		 * ctx->data.content_len = buffer_queue_remove_all(ctx->egress,
+		 *		&ctx->data.content);
+		 */
+		ctx->data.content = buffer_queue_remove_msg(ctx->egress, &ctx->data.content_len);
+		http_request(ctx->uri, http_request_post, http_poll_cb, ctx,
+				&ctx->data, &ctx->opts);
+		ctx->data.content_len = 0;
+		ctx->data.content = NULL;
+		sent = true;
+	}
+
+	if (!sent) {
+		http_request(ctx->uri, http_request_get, http_poll_cb, ctx,
+				&ctx->data, &ctx->opts);
 	}
 
 	if (ctx->running) {

--- a/mettle/src/c2_http.c
+++ b/mettle/src/c2_http.c
@@ -34,12 +34,7 @@ static void patch_uri(struct http_ctx *ctx, struct buffer_queue *q)
 		if (strcmp(method, "core_patch_url") == 0 && new_uri) {
 			char *old_uri = ctx->uri;
 			char *split = ctx->uri;
-			for (int i = 0; i < 3; i++) {
-				if (split == NULL) {
-					break;
-				}
-				split = strchr(++split, '/');
-			}
+			split = strrchr(old_uri, '/');
 			if (split) {
 				*split = '\0';
 			}

--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -139,6 +139,9 @@ static struct tlv_packet * new_request(struct channel *c, const char *method, si
 
 static ssize_t send_write_request(struct channel *c, void *buf, size_t buf_len)
 {
+	if (buf_len == 0) {
+		return 0;
+	}
 	struct tlv_packet *p = new_request(c, "write", buf_len);
 	p = tlv_packet_add_raw(p, TLV_TYPE_CHANNEL_DATA, buf, buf_len);
 	p = tlv_packet_add_u32(p, TLV_TYPE_LENGTH, buf_len);
@@ -147,6 +150,9 @@ static ssize_t send_write_request(struct channel *c, void *buf, size_t buf_len)
 
 ssize_t channel_enqueue_ex(struct channel *c, void *buf, size_t buf_len, struct tlv_packet *extra)
 {
+	if (buf_len == 0) {
+		return 0;
+	}
 	struct tlv_packet *p = new_request(c, "write", buf_len);
 	p = tlv_packet_add_raw(p, TLV_TYPE_CHANNEL_DATA, buf, buf_len);
 	p = tlv_packet_add_u32(p, TLV_TYPE_LENGTH, buf_len);

--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -127,34 +127,6 @@ static struct tlv_packet *core_negotiate_tlv_encryption(struct tlv_handler_ctx *
 	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 }
 
-static struct tlv_packet *core_patch_url(struct tlv_handler_ctx *ctx)
-{
-	struct mettle *m = ctx->arg;
-	char *base_url = NULL, *new_url = NULL;
-	const char *new_path = tlv_packet_get_str(ctx->req, TLV_TYPE_TRANS_URL);
-	struct c2_transport *t = c2_get_current_transport(mettle_get_c2(m));
-	if (new_path && t) {
-		base_url = strdup(c2_transport_uri(t));
-		if (base_url == NULL) {
-			goto out;
-		}
-		char *split = strrchr(base_url, '/');
-		if (split == NULL) {
-			goto out;
-		}
-		*split = '\0';
-
-		if (asprintf(&new_url, "%s%s", base_url, new_path) == -1) {
-			goto out;
-		}
-		log_info("new url %s, old url %s", new_url, c2_transport_uri(t));
-	}
-out:
-	free(base_url);
-	free(new_url);
-	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
-}
-
 void tlv_register_coreapi(struct mettle *m)
 {
 	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
@@ -162,7 +134,6 @@ void tlv_register_coreapi(struct mettle *m)
 	tlv_dispatcher_add_handler(td, "core_enumextcmd", enumextcmd, m);
 	tlv_dispatcher_add_handler(td, "core_machine_id", core_machine_id, m);
 	tlv_dispatcher_add_handler(td, "core_set_uuid", core_set_uuid, m);
-	tlv_dispatcher_add_handler(td, "core_patch_url", core_patch_url, m);
 	tlv_dispatcher_add_handler(td, "core_uuid", core_uuid, m);
 	tlv_dispatcher_add_handler(td, "core_get_session_guid", core_get_session_guid, m);
 	tlv_dispatcher_add_handler(td, "core_set_session_guid", core_set_session_guid, m);

--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -122,8 +122,36 @@ static struct tlv_packet *core_uuid(struct tlv_handler_ctx *ctx)
 	return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 }
 
-static struct tlv_packet *negotiate_tlv_encryption(struct tlv_handler_ctx *ctx)
+static struct tlv_packet *core_negotiate_tlv_encryption(struct tlv_handler_ctx *ctx)
 {
+	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+}
+
+static struct tlv_packet *core_patch_url(struct tlv_handler_ctx *ctx)
+{
+	struct mettle *m = ctx->arg;
+	char *base_url = NULL, *new_url = NULL;
+	const char *new_path = tlv_packet_get_str(ctx->req, TLV_TYPE_TRANS_URL);
+	struct c2_transport *t = c2_get_current_transport(mettle_get_c2(m));
+	if (new_path && t) {
+		base_url = strdup(c2_transport_uri(t));
+		if (base_url == NULL) {
+			goto out;
+		}
+		char *split = strrchr(base_url, '/');
+		if (split == NULL) {
+			goto out;
+		}
+		*split = '\0';
+
+		if (asprintf(&new_url, "%s%s", base_url, new_path) == -1) {
+			goto out;
+		}
+		log_info("new url %s, old url %s", new_url, c2_transport_uri(t));
+	}
+out:
+	free(base_url);
+	free(new_url);
 	return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 }
 
@@ -134,9 +162,10 @@ void tlv_register_coreapi(struct mettle *m)
 	tlv_dispatcher_add_handler(td, "core_enumextcmd", enumextcmd, m);
 	tlv_dispatcher_add_handler(td, "core_machine_id", core_machine_id, m);
 	tlv_dispatcher_add_handler(td, "core_set_uuid", core_set_uuid, m);
+	tlv_dispatcher_add_handler(td, "core_patch_url", core_patch_url, m);
 	tlv_dispatcher_add_handler(td, "core_uuid", core_uuid, m);
 	tlv_dispatcher_add_handler(td, "core_get_session_guid", core_get_session_guid, m);
 	tlv_dispatcher_add_handler(td, "core_set_session_guid", core_set_session_guid, m);
-	tlv_dispatcher_add_handler(td, "core_negotiate_tlv_encryption", negotiate_tlv_encryption, m);
+	tlv_dispatcher_add_handler(td, "core_negotiate_tlv_encryption", core_negotiate_tlv_encryption, m);
 	tlv_dispatcher_add_handler(td, "core_shutdown", core_shutdown, m);
 }

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -69,7 +69,7 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 	while ((c = getopt_long(argc, argv, short_options, options, &index)) != -1) {
 		switch (c) {
 		case 'u':
-			mettle_add_transport_uri(m, optarg);
+			c2_add_transport_uri(mettle_get_c2(m), optarg);
 			break;
 		case 'U':
 			mettle_set_uuid_base64(m, optarg);
@@ -190,7 +190,8 @@ int main(int argc, char * argv[])
 		int fd = (int)((long *)argv)[1];
 		char *uri;
 		if (asprintf(&uri, "fd://%d", fd) > 0) {
-			mettle_add_transport_uri(m, uri);
+			struct c2 *c2 = mettle_get_c2(m);
+			c2_add_transport_uri(c2, uri);
 			free(uri);
 		}
 		parse_default_args(m);

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -80,9 +80,9 @@ int start_heartbeat(struct mettle *m)
 	return 0;
 }
 
-int mettle_add_transport_uri(struct mettle *m, const char *uri)
+struct c2 * mettle_get_c2(struct mettle *m)
 {
-	return c2_add_transport_uri(m->c2, uri);
+	return m->c2;
 }
 
 struct ev_loop * mettle_get_loop(struct mettle *m)

--- a/mettle/src/mettle.h
+++ b/mettle/src/mettle.h
@@ -7,6 +7,7 @@
 #ifndef _METTLE_H_
 #define _METTLE_H_
 
+#include "c2.h"
 #include "channel.h"
 #include "process.h"
 
@@ -33,7 +34,7 @@ struct tlv_dispatcher *mettle_get_tlv_dispatcher(struct mettle *m);
 
 void mettle_free(struct mettle *);
 
-int mettle_add_transport_uri(struct mettle *m, const char *uri);
+struct c2 * mettle_get_c2(struct mettle *m);
 
 struct channelmgr * mettle_get_channelmgr(struct mettle *m);
 


### PR DESCRIPTION
These are temporary fixes for https://github.com/rapid7/metasploit-framework/issues/8860 (and a few cleanups I'd like to get in the tree anyway). Basically Metasploit's HTTP transport support does not handle multiple TLV packets in a single request, which we need to fix later. For now this clamps mettle to 1 TLV per request like the other Meterpreters. 