### PR TITLE
bump toolchains, add e500v2 support

### DIFF
--- a/ARCHES
+++ b/ARCHES
@@ -4,6 +4,7 @@ i486-linux-musl
 aarch64-linux-musl
 armv5l-linux-musleabi
 armv5b-linux-musleabi
+powerpc-e500v2-linux-musl
 powerpc-linux-muslsf
 powerpc64le-linux-musl
 mips-linux-muslsf

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -1,5 +1,5 @@
 BUILD_HOST=linux
-TOOLCHAIN_VERSION=4
+TOOLCHAIN_VERSION=5
 ifneq "$(TARGET)" "native"
     ifneq (,$(findstring musl,$(TARGET)))
         CC=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-gcc


### PR DESCRIPTION
This adds support for a popular CPU architecture commonly found in switches, routers, and printers.

The actual toolchain changes are here: https://github.com/busterb/musl-cross-make/commit/d3d616a38e7530a8ea691dcce3f06fb06626e160 and here https://github.com/busterb/musl/commits/stealthy-loading