### PR TITLE
Shrinking mettle.bin

### DIFF
--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -28,6 +28,9 @@ else
             METTLE_DEPS += $(BUILD)/lib/libmbedtls.a
             METTLE_OPTS += --enable-staticpie
         endif
+        ifneq (,$(findstring x86_64,$(TARGET)))
+            CFLAGS += -Wl,-z,max-page-size=4096
+        endif
     endif
 endif
 

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -57,7 +57,7 @@ AM_CONDITIONAL([HOST_WIN],     [test x$HOST_OS = xwin])
 
 CHECK_LIBC_COMPAT
 
-CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function"
+CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function -Wl,-z,max-page-size=4096"
 
 AC_CONFIG_FILES([
 	Makefile

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -57,7 +57,7 @@ AM_CONDITIONAL([HOST_WIN],     [test x$HOST_OS = xwin])
 
 CHECK_LIBC_COMPAT
 
-CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function -Wl,-z,max-page-size=4096"
+CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function"
 
 AC_CONFIG_FILES([
 	Makefile


### PR DESCRIPTION
There is a Metasploit issue titled "[Implement simple compression / encoding of meterpreter stage](https://github.com/rapid7/metasploit-framework/issues/8387)".

Essentially, this issue observes that the x64 binary is 700kb but due to the way that elf2bin works mettle.bin balloons to 3mb. For those who don't know, elf2bin includes the extra space between segments in mettle.bin. The reason that mettle.bin is so large for x64 is that that the linker aligns each segment on a 0x200000 boundary.

However, we can simply tell the linker that the max page size is 4096 and that will change the segment alignment to 4096. As far as I know, there are no negative side effects and the mettle.bin shrinks.

Before:
```sh
albinolobster@ubuntu:~/dev/mettle$ ls -l ./build/x86_64-linux-musl/bin/mettle*
-rwxr-xr-x 1 albinolobster albinolobster  729184 Oct 20 17:59 ./build/x86_64-linux-musl/bin/mettle
-rw-r--r-- 1 albinolobster albinolobster 2878896 Oct 20 17:59 ./build/x86_64-linux-musl/bin/mettle.bin
```

After:
```
albinolobster@ubuntu:~/dev/mettle$ ls -l ./build/x86_64-linux-musl/bin/mettle*
-rwxr-xr-x 1 albinolobster albinolobster 729184 Oct 20 18:07 ./build/x86_64-linux-musl/bin/mettle
-rw-r--r-- 1 albinolobster albinolobster 785840 Oct 20 18:07 ./build/x86_64-linux-musl/bin/mettle.bin
```