### PR TITLE
force BPF for darwin targets

### DIFF
--- a/make/Makefile.libpcap
+++ b/make/Makefile.libpcap
@@ -12,6 +12,10 @@ ifneq (,$(findstring -linux-,$(TARGET)))
     LIBPCAP_CONFIG_FLAGS=--with-pcap=linux
 endif
 
+ifneq (,$(findstring -darwin,$(TARGET)))
+    LIBPCAP_CONFIG_FLAGS=--with-pcap=bpf
+endif
+
 $(BUILD)/libpcap/Makefile: build/tools $(BUILD)/libpcap/configure $(LIBPCAP_DEPS)
 	@echo "Configuring libpcap for $(TARGET)"
 	@mkdir -p $(BUILD)/libpcap


### PR DESCRIPTION
I tried building on ios targets with libpcap and it could not determine the --with-pcap when cross compiling for ARM. Unfortunately fixing that just moves us to the next break in the build, but this gets us a step closer. Maybe @timwr would have a clue what else we need here.