### PR TITLE
Support loading extensions via gem API.

### DIFF
--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -92,15 +92,15 @@ module MetasploitPayloads
     #
     # Get the contents of any file packaged in this gem by local path and name.
     #
-    def self.read(triple, format)
+    def self.read(triple, format, filename = "mettle")
       file =
           case format
           when :process_image
-            'mettle.bin'
+            "#{filename}.bin"
           when :exec
-            'mettle'
+            "#{filename}"
           else
-            fail RuntimeError, "unknown mettle format #{format}", caller
+            fail RuntimeError, "unknown format #{format} for #{filename}", caller
           end
       file_path = path("#{triple}", 'bin', file)
       if file_path.nil?
@@ -155,5 +155,34 @@ module MetasploitPayloads
         @local_paths << path
       end
     end
+
+    #
+    # List extensions which are available for loading
+    #
+    def self.available_extensions(platform)
+      dir_path = path("#{platform}", 'bin')
+      if dir_path.nil?
+        full_path = ::File.join([platform, 'bin'])
+        fail RuntimeError, "#{full_path} not found", caller
+      end
+
+      extensions = ::Dir.entries(dir_path)
+      # Only return extensions!
+      extensions - [ '.', '..', 'mettle', 'mettle.bin' ]
+    end
+
+    #
+    # Load and return the contents of an extension as an object
+    #
+    def self.load_extension(platform, name, suffix = '')
+      if suffix == 'bin'
+        format = :process_image
+      else
+        format = :exec
+        name = [name,suffix].join('.') unless suffix.blank?
+      end
+      self.read(platform, format, name)
+    end
+
   end
 end

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -58,6 +58,7 @@ AM_CONDITIONAL([HOST_WIN],     [test x$HOST_OS = xwin])
 CHECK_LIBC_COMPAT
 
 CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function"
+CFLAGS="$CFLAGS -DBUILD_TUPLE=\\\"$TARGET\\\""
 
 AC_CONFIG_FILES([
 	Makefile

--- a/mettle/src/stdapi/sys/config.c
+++ b/mettle/src/stdapi/sys/config.c
@@ -82,6 +82,7 @@ struct tlv_packet *sys_config_sysinfo(struct tlv_handler_ctx *ctx)
 	p = tlv_packet_add_fmt(p, TLV_TYPE_OS_NAME, "%s (%s %s)",
 			sys_info.description, sys_info.name, sys_info.version);
 	p = tlv_packet_add_str(p, TLV_TYPE_ARCHITECTURE, sys_info.arch);
+	p = tlv_packet_add_str(p, TLV_TYPE_BUILD_TUPLE, BUILD_TUPLE);
 
 	return p;
 }

--- a/mettle/src/tlv_types.h
+++ b/mettle/src/tlv_types.h
@@ -195,6 +195,7 @@
 #define TLV_TYPE_ARCHITECTURE          (TLV_META_TYPE_STRING  | 1043)
 #define TLV_TYPE_SID                   (TLV_META_TYPE_STRING  | 1045)
 #define TLV_TYPE_LOCAL_DATETIME        (TLV_META_TYPE_STRING  | 1048)
+#define TLV_TYPE_BUILD_TUPLE           (TLV_META_TYPE_STRING  | 1049)
 
 /*
  * Environment


### PR DESCRIPTION
Added available_extensions() and load_extension() class methods to Mettle.  This allows MSF to not know or care where extensions are stored in any gem, it just calls the API methods and the gem handles the details.

I updated my Mettle Extensions framework branch with a corresponding change that will work with the changes here.  I have NOT bumped any gem version numbers, and I may have missed something with updating the payload sizes...