### PR TITLE
Fix cmd exec issues

### DIFF
--- a/mettle/src/channel.h
+++ b/mettle/src/channel.h
@@ -60,6 +60,8 @@ void channel_set_ctx(struct channel *c, void *ctx);
 
 struct channel_callbacks * channel_get_callbacks(struct channel *c);
 
+void channel_set_eof(struct channel *c);
+
 void channel_set_interactive(struct channel *c, bool enable);
 
 bool channel_get_interactive(struct channel *c);

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -61,7 +61,8 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 	};
 	const char *short_options = "hu:U:G:d::o:b::p:n:";
 	const char *out = NULL;
-	char *name = strdup("service");
+	char *name = strdup("mettle");
+	bool name_flag = false;
 	bool debug = false;
 	bool background = false;
 	enum persist_type persist = persist_none;
@@ -86,6 +87,7 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 		case 'n':
 			free(name);
 			name = strdup(optarg);
+			name_flag = true;
 			break;
 		case 'p':
 			if (strcmp("install", optarg) == 0) {
@@ -137,7 +139,7 @@ static int parse_cmdline(int argc, char * const argv[], struct mettle *m)
 		start_logger(out);
 	}
 
-	if (name) {
+	if (name_flag) {
 		log_info("using name: %s", name);
 		setproctitle(name);
 	}

--- a/mettle/src/process.c
+++ b/mettle/src/process.c
@@ -178,10 +178,6 @@ static void exec_child(struct procmgr *mgr,
 		setenv("PATH", def_path, 1);
 	}
 
-	if (proc[0] == '/' && access(proc, X_OK)) {
-		proc = basename(proc);
-	}
-
 	if (opts && opts->args) {
 		if (asprintf(&args, "%s %s", proc, opts->args) <= 0) {
 			abort();
@@ -199,6 +195,9 @@ static void exec_child(struct procmgr *mgr,
 		size_t argc = 0;
 		char **argv = NULL;
 		argv = argv_split(args, argv, &argc);
+		if (argv[0][0] == '/' && access(argv[0], X_OK)) {
+			argv[0] = basename(argv[0]);
+		}
 		execvp(file, argv);
 	}
 	abort();

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -173,6 +173,7 @@ struct tlv_packet *sys_process_wait(struct tlv_handler_ctx *ctx)
 struct channelmgr_ctx {
 	struct channelmgr *cm;
 	uint32_t channel_id;
+	bool eof;
 };
 
 /*
@@ -209,10 +210,13 @@ static void process_channel_exit_cb(struct process *p, int exit_status, void *ar
 {
 	struct channelmgr_ctx *cm_ctx = arg;
 	struct channel *c = channelmgr_channel_by_id(cm_ctx->cm, cm_ctx->channel_id);
+	cm_ctx->eof = true;
 	if (c && channel_get_interactive(c)) {
 		channel_send_close_request(c);
+		free(cm_ctx);
+	} else {
+		channel_set_eof(c);
 	}
-	free(cm_ctx);
 }
 
 static void process_channel_read_cb(struct process *p, struct buffer_queue *queue, void *arg)


### PR DESCRIPTION
This fixes a few issues with running cmd_exec, and one problem with the new process rename function (it would always trigger even if nothing was specified).

Part of a fix for https://github.com/rapid7/metasploit-framework/issues/9429