### PR TITLE
disable process rename machinery on injected processes

### DIFF
--- a/lib/metasploit_payloads/mettle/version.rb
+++ b/lib/metasploit_payloads/mettle/version.rb
@@ -1,7 +1,7 @@
 # -*- coding:binary -*-
 module MetasploitPayloads
   class Mettle
-    VERSION = '0.3.5'
+    VERSION = '0.3.6'
 
     def self.version
       VERSION


### PR DESCRIPTION
argv/argc are lies in this case, since the stager uses them as as back channel to pass file descriptors. If we parse them, the payload will crash. Renaming an injected process probably isn't good opsec anyway :)