### PR TITLE
flush data on child exit, fix incorrect file descriptors in process struct

### DIFF
--- a/mettle/src/process.c
+++ b/mettle/src/process.c
@@ -389,7 +389,7 @@ static struct process * process_create(struct procmgr *mgr,
 	/*
 	 * Register stdout watcher
 	 */
-	p->out_fd = stdout_pair[1];
+	p->out_fd = stdout_pair[0];
 	fcntl(stdout_pair[0], F_SETFL, O_NONBLOCK);
 	p->out.queue = buffer_queue_new();
 	p->out.w.data = p;
@@ -399,12 +399,14 @@ static struct process * process_create(struct procmgr *mgr,
 	/*
 	 * Register stderr watcher
 	 */
-	p->err_fd = stderr_pair[1];
+	p->err_fd = stderr_pair[0];
 	fcntl(stderr_pair[0], F_SETFL, O_NONBLOCK);
 	p->err.queue = buffer_queue_new();
 	p->err.w.data = p;
 	ev_io_init(&p->err.w, stderr_cb, stderr_pair[0], EV_READ);
 	ev_io_start(mgr->loop, &p->err.w);
+
+	log_debug("IO started on fds %d %d", p->out_fd, p->err_fd);
 
 	return p;
 }

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -257,7 +257,7 @@ sys_process_execute(struct tlv_handler_ctx *ctx)
 		.user = NULL,
 	};
 
-	struct process *p = process_create_from_executable(pm, path, &opts, true);
+	struct process *p = process_create_from_executable(pm, path, &opts, PROCESS_CREATE_SUBSHELL);
 	if (p == NULL) {
 		return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/9482 by ensuring we flush the child process file descriptors when the process exits, also correcting a bug in the process manager where the child's and not the parent's file descriptors were stored in the process structure.

Verification steps:

Build and install this PR, then run the test in the above issue.

```
[*] Started reverse TCP handler on 192.168.86.35:4444 
test
test
test
test
test
test
test
test
test
test
we made it to the end
[*] Exploit completed, but no session was created.
msf5 exploit(test/9482) > sessions -1 -C sysinfo
[*] Running 'sysinfo' on meterpreter session 1 (192.168.56.102)
Computer     : localhost.localdomain
OS           : CentOS 5 (Linux 2.6.18-8.el5)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x86/linux
```

While this addresses some issues triggered by old Linux kernel versions (newer ones signal read status on child file descriptors before triggering SIGCHLD, but we shouldn't rely on that behavior), I'd like to make a later PR that adds a more efficient interface for invoking commands like this in the first place.