### PR TITLE
Initial Solaris 11 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build
 *.xz
 pkg/
 mettle.xcodeproj
+Gemfile.lock

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -1,5 +1,6 @@
 BUILD_HOST=linux
 TOOLCHAIN_VERSION=6
+INSTALL=install
 ifneq "$(TARGET)" "native"
     ifneq (,$(findstring musl,$(TARGET)))
         CC=$(ROOT)/build/tools/musl-cross/bin/$(TARGET)-gcc
@@ -33,6 +34,11 @@ ifneq "$(TARGET)" "native"
         CPPFLAGS:=$(CPPFLAGS) $(ADDFLAGS)
         LDFLAGS:=$(LDFLAGS) $(ADDFLAGS)
     endif
+    ifneq (,$(findstring sunos,$(TARGET)))
+        CC=gcc
+        AR=gar
+        INSTALL=ginstall
+    endif
 endif
 
 TAR=tar
@@ -42,7 +48,6 @@ $(ELF2BIN): util/elf2bin.c
 	@mkdir -p build/tools
 	@cc -g -o $@ $<
 
-INSTALL=install
 export PATH:=$(ROOT)/build/tools/musl-cross/bin:$(PATH)
 ifeq "$(shell uname -s)" "Darwin"
     BUILD_HOST=osx

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -49,6 +49,11 @@ case $host_os in
 		LDFLAGS="$LDFLAGS -static-libgcc"
 		AC_SUBST([PLATFORM_LDADD], ['-lws2_32 -lwinpthread -static --static'])
 		;;
+	*solaris*)
+		HOST_OS=solaris
+		CPPFLAGS="$CPPFLAGS -D__EXTENSIONS__ -D_XOPEN_SOURCE=600 -DBSD_COMP -D_POSIX_PTHREAD_SEMANTICS"
+		AC_SUBST([PLATFORM_LDADD], ['-lnsl -lsocket'])
+
 esac
 
 AM_CONDITIONAL([HOST_IOS],     [test x$HOST_OS = xios])

--- a/mettle/extensions/sniffer/Makefile.am
+++ b/mettle/extensions/sniffer/Makefile.am
@@ -3,8 +3,8 @@ bin_PROGRAMS = sniffer
 endif
 
 sniffer_LDADD = -ldnet
-sniffer_LDADD += -lmettle
 sniffer_LDADD += -lpcap
+sniffer_LDADD += $(abs_top_builddir)/src/libmettle.la
 sniffer_SOURCES = sniffer.c
 
 sniffer_CFLAGS = -I$(top_srcdir)/src

--- a/mettle/include/compat/endian.h
+++ b/mettle/include/compat/endian.h
@@ -17,6 +17,50 @@
 
 #	include_next <endian.h>
 
+#elif defined(__sun)
+
+#include <sys/byteorder.h>
+#define bswap_16(x) BSWAP_16(x)
+#define bswap_32(x) BSWAP_32(x)
+#define bswap_64(x) BSWAP_64(x)
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+
+#ifdef _LITTLE_ENDIAN
+#define __BYTE_ORDER __LITTLE_ENDIAN
+
+#	define htobe16(x) htons(x)
+#	define htole16(x) (x)
+#	define be16toh(x) ntohs(x)
+#	define le16toh(x) (x)
+
+#	define htobe32(x) htonl(x)
+#	define htole32(x) (x)
+#	define be32toh(x) ntohl(x)
+#	define le32toh(x) (x)
+
+#	define htobe64(x) htonll(x)
+#	define htole64(x) (x)
+#	define be64toh(x) ntohll(x)
+#	define le64toh(x) (x)
+#else
+#define __BYTE_ORDER __BIG_ENDIAN
+#	define htobe16(x) (x)
+#	define htole16(x) __builtin_bswap16(x)
+#	define be16toh(x) (x)
+#	define le16toh(x) __builtin_bswap16(x)
+
+#	define htobe32(x) (x)
+#	define htole32(x) __builtin_bswap32(x)
+#	define be32toh(x) (x)
+#	define le32toh(x) __builtin_bswap32(x)
+
+#	define htobe64(x) (x)
+#	define htole64(x) __builtin_bswap64(x)
+#	define be64toh(x) (x)
+#	define le64toh(x) __builtin_bswap64(x)
+#endif
+
 #elif defined(__APPLE__)
 
 #	include <libkern/OSByteOrder.h>

--- a/mettle/src/process.c
+++ b/mettle/src/process.c
@@ -389,7 +389,7 @@ static struct process * process_create(struct procmgr *mgr,
 	p->mgr = mgr;
 	HASH_ADD_INT(mgr->processes, pid, p);
 
-	log_debug("child pid %u started", p->pid);
+	log_debug("child pid %lu started", (unsigned long)p->pid);
 
 	/*
 	 * Register exit handler

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -17,8 +17,8 @@ get_process_info(sigar_t *sigar, sigar_pid_t pid)
 	sigar_proc_state_t pstate;
 	int status = sigar_proc_state_get(sigar, pid, &pstate);
 	if (status != SIGAR_OK) {
-		log_debug("error: %d (%s) proc_state(%d)",
-			status, sigar_strerror(sigar, status), pid);
+		log_debug("error: %d (%s) proc_state(%lu)",
+			status, sigar_strerror(sigar, status), (unsigned long)pid);
 		return NULL;
 	}
 
@@ -52,8 +52,8 @@ get_process_info(sigar_t *sigar, sigar_pid_t pid)
 	if (status == SIGAR_OK) {
 		p = tlv_packet_add_str(p, TLV_TYPE_USER_NAME, uname_data.user);
 	} else {
-		log_debug("error: %d (%s) proc_state(%d)",
-			status, sigar_strerror(sigar, status), pid);
+		log_debug("error: %d (%s) proc_state(%lu)",
+			status, sigar_strerror(sigar, status), (unsigned long)pid);
 	}
 
 	return p;


### PR DESCRIPTION
@bcoles was interested in this. Builds on Solaris 11.3 stock install with:

```
# pkg add gcc flex bison automake autoconf libtool gnu-coreutils
# ln -s /usr/bin/gcc /usr/bin/cc
# ln -s /usr/bin/ginstall /usr/bin/install
# export AR=gar
# gmake
```

The build system isn't the prettiest because we need gnu tools for a few things that don't seem to work nicely with native versions. This doesn't use elf2bin to build a binfile either (or add it to the gem), but I think it will work with a little tweaking. Here's a quick test run using the stageless linux handler as a stand-in for testing:

```
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Meterpreter session 8 opened (192.168.56.1:4444 -> 192.168.56.1:58736) at 2018-04-05 04:14:53 -0500

meterpreter > sysinfo
Computer     : solaris
OS           : Solaris 11 (Solaris 5.11)
Architecture : i386
BuildTuple   : 
Meterpreter  : x64/linux
```