### PR TITLE
fix crash in #129

### DIFF
--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -428,6 +428,7 @@ static struct tlv_packet *channel_tell(struct tlv_handler_ctx *ctx)
 	struct tlv_packet *p;
 	if (cbs->tell_cb == NULL) {
 		p = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
+		return p;
 	}
 
 	ssize_t offset = cbs->tell_cb(c);


### PR DESCRIPTION
This doesn't quite fix the bug, as the output is still a little funky, but it does fix the crash and the upload completes successfully:
e.g:
```
[*] uploading  : README.md -> README.md
[*] Uploaded -1.00 B of 2.48 KiB (-0.04%): README.md -> README.md
[*] uploaded   : README.md -> README.md
```