### PR TITLE
fix #140

### DIFF
--- a/mettle/src/c2.c
+++ b/mettle/src/c2.c
@@ -120,20 +120,17 @@ int c2_add_transport_uri(struct c2 *c2, const char *uri)
 	struct c2_transport *t = NULL;
 	struct c2_transport_type *type = c2_find_transport_type(c2, uri);
 	if (type == NULL) {
-		fprintf(stderr, "a");
 		goto err;
 	}
 
 	t = calloc(1, sizeof *t);
 	if (t == NULL) {
-		fprintf(stderr, "a");
 		goto err;
 	}
 	t->c2 = c2;
 	t->type = type;
 	t->uri = strdup(uri);
 	if (t->uri == NULL) {
-		fprintf(stderr, "b");
 		goto err;
 	}
 
@@ -142,7 +139,6 @@ int c2_add_transport_uri(struct c2 *c2, const char *uri)
 	 */
 	t->dest = strstr(t->uri, "://");
 	if (t->dest == NULL || strlen(t->dest) < 4) {
-		fprintf(stderr, "c");
 		goto err;
 	}
 	t->dest += 3;
@@ -155,7 +151,6 @@ int c2_add_transport_uri(struct c2 *c2, const char *uri)
 
 	return 0;
 err:
-	fprintf(stderr, "erg");
 	if (t) {
 		free(t->uri);
 		free(t);

--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -132,8 +132,8 @@ static struct tlv_packet *core_negotiate_tlv_encryption(struct tlv_handler_ctx *
 			if ((enc_len = rsa_encrypt_pkcs(pkey, pkey_len, enc_ctx, buf)) > 0)
 			{
 				struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
-				tlv_packet_add_u32(p, TLV_TYPE_SYM_KEY_TYPE, ENC_AES256);
-				tlv_packet_add_raw(p, TLV_TYPE_ENC_SYM_KEY, buf, enc_len);
+				p = tlv_packet_add_u32(p, TLV_TYPE_SYM_KEY_TYPE, ENC_AES256);
+				p = tlv_packet_add_raw(p, TLV_TYPE_ENC_SYM_KEY, buf, enc_len);
 				tlv_dispatcher_add_encryption(td, enc_ctx);
 				return p;
 			}

--- a/mettle/src/crypttlv.c
+++ b/mettle/src/crypttlv.c
@@ -84,7 +84,7 @@ void free_tlv_encryption_ctx(struct tlv_encryption_ctx *ctx)
 		free(ctx->key);
 	if (ctx->iv != NULL)
 		free(ctx->iv);
-	return free(ctx);
+	free(ctx);
 }
 
 void * decrypt_tlv(struct tlv_encryption_ctx* ctx, void *p, size_t buf_len)
@@ -128,12 +128,12 @@ void * encrypt_tlv(struct tlv_encryption_ctx* ctx, void *p, size_t buf_len)
 					memcpy(&hdr->tlv, tlv_buf, tlv_len);
 					unsigned char *tlv_data = out_buf + sizeof(struct tlv_xor_header);
 					memset(tlv_data + value_len, pad_len, pad_len);
-					unsigned char result[enc_size];
-					memset(result, 0, enc_size);
 					if (ctx->initialized) {
 						hdr->encryption_flags = htonl(ctx->flag);
 						unsigned char iv[AES_IV_LEN];
 						memcpy(iv, ctx->iv, AES_IV_LEN); // grab iv before enc manipulates it.
+						unsigned char result[enc_size];
+						memset(result, 0, enc_size);
 						if ((length = aes_encrypt(ctx, tlv_data, enc_size, result)) > 0) {
 							memcpy(tlv_data, iv, AES_IV_LEN);
 							memcpy(tlv_data + AES_IV_LEN, result, length);
@@ -142,7 +142,6 @@ void * encrypt_tlv(struct tlv_encryption_ctx* ctx, void *p, size_t buf_len)
 							break;
 						}
 					} else {
-						free(out_buf);
 						ctx->initialized = true;
 					}
 				}


### PR DESCRIPTION
I think this is only reproducible on arm-iphone-darwin.
The important fix was https://github.com/rapid7/mettle/pull/142/files#diff-9f5058504ba42640606d3d00a6fcfdaaL135
Without it we're allocating memory with realloc and then using the old pointer.