### PR TITLE
disable USB capture support

### DIFF
--- a/make/Makefile.libpcap
+++ b/make/Makefile.libpcap
@@ -8,7 +8,7 @@ $(BUILD)/libpcap/configure:
 		$(TAR) zxf $(ROOT)/deps/libpcap-$(LIBPCAP_VERSION).tar.gz; \
 		mv libpcap-$(LIBPCAP_VERSION) libpcap
 
-LIBPCAP_CONFIG_FLAGS = --disable-dbus
+LIBPCAP_CONFIG_FLAGS = --disable-dbus --disable-usb
 ifneq (,$(findstring -linux-,$(TARGET)))
     LIBPCAP_CONFIG_FLAGS += --with-pcap=linux
 endif


### PR DESCRIPTION
Currently we let autoconf decide, and it can make mistakes that lead to compilation failures.

Specifically:
```
03:15:47 Building libpcap for x86_64-linux-musl
03:15:49 [01m[K./pcap-usb-linux.c:[m[K In function '[01m[Kusb_findalldevs[m[K':
03:15:49 [01m[K./pcap-usb-linux.c:264:19:[m[K [01;31m[Kerror: [m[K'[01m[KPATH_MAX[m[K' undeclared (first use in this function); did you mean '[01m[KAF_MAX[m[K'?
03:15:49   char usb_mon_dir[[01;31m[KPATH_MAX[m[K];
03:15:49                    [01;31m[K^~~~~~~~[m[K
03:15:49                    [32m[KAF_MAX[m[K
03:15:49 [01m[K./pcap-usb-linux.c:264:19:[m[K [01;36m[Knote: [m[Keach undeclared identifier is reported only once for each function it appears in
03:15:49 [01m[K./pcap-usb-linux.c:[m[K In function '[01m[Kprobe_devices[m[K':
03:15:49 [01m[K./pcap-usb-linux.c:419:41:[m[K [01;31m[Kerror: [m[K'[01m[KNAME_MAX[m[K' undeclared (first use in this function); did you mean '[01m[KAF_MAX[m[K'?
03:15:49   char buf[sizeof("/dev/bus/usb/000/") + [01;31m[KNAME_MAX[m[K];
03:15:49                                          [01;31m[K^~~~~~~~[m[K
03:15:49                                          [32m[KAF_MAX[m[K
03:15:49 make[1]: *** [pcap-usb-linux.o] Error 1
03:15:49 [01m[K./pcap-usb-linux.c:[m[K In function '[01m[Kusb_findalldevs[m[K':
03:15:49 [01m[K./pcap-usb-linux.c:264:19:[m[K [01;31m[Kerror: [m[K'[01m[KPATH_MAX[m[K' undeclared (first use in this function); did you mean '[01m[KAF_MAX[m[K'?
```