### PR TITLE
fix ls of 4gb files, use 64bit for st_size

### DIFF
--- a/mettle/src/stdapi/fs/file.c
+++ b/mettle/src/stdapi/fs/file.c
@@ -42,11 +42,11 @@ add_stat(struct tlv_packet *p, EIO_STRUCT_STAT *s)
 		uint16_t gid;
 		uint16_t pad;
 		uint32_t rdev;
-		uint32_t size;
+		uint64_t size;
 		uint64_t atime;
 		uint64_t mtime;
 		uint64_t ctime;
-	} ms = {
+	} __attribute__((__packed__)) ms = {
 		.dev = htole32(s->st_dev),
 		.ino = htole16(s->st_ino),
 		.mode = htole16(s->st_mode),
@@ -54,7 +54,7 @@ add_stat(struct tlv_packet *p, EIO_STRUCT_STAT *s)
 		.uid = htole16(s->st_uid),
 		.gid = htole16(s->st_gid),
 		.rdev = htole32(s->st_rdev),
-		.size = htole32(s->st_size),
+		.size = htole64(s->st_size),
 #ifndef _WIN32
 		.mtime = htole64(s->st_mtim.tv_sec),
 		.atime = htole64(s->st_atim.tv_sec),

--- a/mettle/src/tlv_types.h
+++ b/mettle/src/tlv_types.h
@@ -119,7 +119,7 @@
 #define TLV_TYPE_FILE_SIZE             (TLV_META_TYPE_UINT    | 1204)
 #define TLV_TYPE_FILE_HASH             (TLV_META_TYPE_RAW     | 1206)
 
-#define TLV_TYPE_STAT_BUF              (TLV_META_TYPE_COMPLEX | 1220)
+#define TLV_TYPE_STAT_BUF              (TLV_META_TYPE_COMPLEX | 1221)
 
 #define TLV_TYPE_SEARCH_RECURSE        (TLV_META_TYPE_BOOL    | 1230)
 #define TLV_TYPE_SEARCH_GLOB           (TLV_META_TYPE_STRING  | 1231)


### PR DESCRIPTION
See https://github.com/rapid7/metasploit-framework/pull/11193