### PR TITLE
remove lock on bundler in gemspec

### DIFF
--- a/metasploit_payloads-mettle.gemspec
+++ b/metasploit_payloads-mettle.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'gem-release'
 end


### PR DESCRIPTION
Just remove the lock on bundler development dependency to allow compatiblility with bundler 2.x