### PR TITLE
patch mbedtls mips registers

### DIFF
--- a/deps/mbedtls_mips.patch
+++ b/deps/mbedtls_mips.patch
@@ -1,0 +1,13 @@
+diff --git a/include/mbedtls/bn_mul.h b/include/mbedtls/bn_mul.h
+index 80e4b380d..9d32f2bac 100644
+--- a/include/mbedtls/bn_mul.h
++++ b/include/mbedtls/bn_mul.h
+@@ -734,7 +734,7 @@
+         "sw     $10, %2         \n\t"   \
+         : "=m" (c), "=m" (d), "=m" (s)                      \
+         : "m" (s), "m" (d), "m" (c), "m" (b)                \
+-        : "$9", "$10", "$11", "$12", "$13", "$14", "$15"    \
++        : "$9", "$10", "$11", "$12", "$13", "$14", "$15", "lo", "hi" \
+     );
+
+ #endif /* MIPS */

--- a/make/Makefile.mbedtls
+++ b/make/Makefile.mbedtls
@@ -15,6 +15,9 @@ $(BUILD)/lib/libmbedtls.a: $(TOOLS)
 		mv mbedtls-$(MBEDTLS_VERSION) mbedtls; \
 		cp $(DEPS)/mbedtls-config.h mbedtls/include/mbedtls/config.h; \
 		sed -ibak 's/-no_warning_for_no_symbols//' mbedtls/library/Makefile
+	@echo "Applying MIPS register patch"
+	@cd $(BUILD)/mbedtls; \
+		patch -b -p1 < $(DEPS)/mbedtls_mips.patch
 	@echo "Building mbedtls for $(TARGET)"
 	@$(SETUP_BUILDENV) cd $(BUILD)/mbedtls; \
 		$(ENV) $(MBEDTLS_ENV) $(MAKE) lib $(LOGBUILD); \


### PR DESCRIPTION
This makes the mips mbedtls patch from #136 independent of the committed version being built.

This patch should be deprecated soon as PR to mbedtls is approved to land in the near future.