### PR TITLE
conditionally build liblinenoise / console

### DIFF
--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -25,6 +25,7 @@ ifneq (,$(findstring darwin,$(BUILD)))
 else
     ifneq (,$(findstring mingw,$(BUILD)))
     else
+        METTLE_DEPS += $(BUILD)/lib/liblinenoise.a
         METTLE_DEPS += $(BUILD)/lib/libpcap.a
         ifneq "$(TARGET)" "native"
             METTLE_TARGETS += $(BUILD)/bin/mettle.bin
@@ -43,7 +44,6 @@ $(BUILD)/mettle/Makefile: $(TOOLS) $(ROOT)/mettle/configure \
 	$(BUILD)/lib/libcurl.a \
 	$(BUILD)/lib/libeio.a \
 	$(BUILD)/lib/libev.a \
-	$(BUILD)/lib/liblinenoise.a \
 	$(BUILD)/lib/libsigar.a \
 	$(BUILD)/lib/libdnet.a
 	@echo "Configuring mettle for $(TARGET)"

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -22,7 +22,11 @@ libmettle_la_SOURCES += c2.c
 libmettle_la_SOURCES += c2_http.c
 libmettle_la_SOURCES += c2_tcp.c
 libmettle_la_SOURCES += channel.c
+if HOST_WIN
+libmettle_la_SOURCES += console-unsupported.c
+else
 libmettle_la_SOURCES += console.c
+endif
 libmettle_la_SOURCES += coreapi.c
 libmettle_la_SOURCES += crypttlv.c
 libmettle_la_SOURCES += extension.c

--- a/mettle/src/console-unsupported.c
+++ b/mettle/src/console-unsupported.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+#include <mettle.h>
+
+void mettle_console_start_interactive(struct mettle *m)
+{
+	printf("interactive console not supported on this platform\n");
+}


### PR DESCRIPTION
There is incompatibility with older mingw, let's hold off building console on Windows for now.