### PR TITLE
remove libstdc++ from build

### DIFF
--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -11,7 +11,6 @@ libmettle_la_LIBADD += -ljson-c
 libmettle_la_LIBADD += -lpthread
 libmettle_la_LIBADD += -lsigar
 libmettle_la_LIBADD += -lz
-libmettle_la_LIBADD += -lstdc++
 
 libmettle_la_SOURCES = mettle.c
 libmettle_la_SOURCES += argv_split.c


### PR DESCRIPTION
And, because we are not linking C++ code, don't link libstdc++ (which screws with builds anyway with our current toolchains).