### PR TITLE
don't package tools in the gem builds

### DIFF
--- a/metasploit_payloads-mettle.gemspec
+++ b/metasploit_payloads-mettle.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = '3-clause (or "modified") BSD'
 
   spec.files         = `git ls-files lib/`.split("\n")
-  spec.files        += Dir['build/*/bin/*'].reject { |file| file =~ /^build\/tools/ }
+  spec.files        += Dir['build/*/bin/*'].reject { |file| file.start_with? "build/tools" }
   spec.executables   = []
   spec.require_paths = ['lib']
 

--- a/metasploit_payloads-mettle.gemspec
+++ b/metasploit_payloads-mettle.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = '3-clause (or "modified") BSD'
 
   spec.files         = `git ls-files lib/`.split("\n")
-  spec.files        += Dir['build/*/bin/*']
+  spec.files        += Dir['build/*/bin/*'].reject { |file| file =~ /^build\/tools/ }
   spec.executables   = []
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
Noticed by @jmartin-r7 we shouldn't package build tools with gem builds.