### PR TITLE
fix shell subshell

### DIFF
--- a/mettle/src/process.c
+++ b/mettle/src/process.c
@@ -186,11 +186,13 @@ static void exec_child(struct procmgr *mgr,
 		args = proc;
 	}
 
+	char *sh = NULL;
 	if (opts->flags & PROCESS_CREATE_SUBSHELL) {
-		const char *sh = shell_path();
-		if (sh) {
-			execl(sh, sh, "-c", args, (char *)NULL);
-		}
+		sh = shell_path();
+	}
+
+	if (sh) {
+		execl(sh, sh, "-c", args, (char *)NULL);
 	} else {
 		size_t argc = 0;
 		char **argv = NULL;

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -252,8 +252,13 @@ sys_process_execute(struct tlv_handler_ctx *ctx)
 	struct process_options opts = {
 		.process_name = path,
 		.args = args,
-		.flags = flags,
+		.flags = 0
 	};
+
+	if (strchr(path, '$') != NULL || strchr(path, '%') != NULL ||
+	    strchr(args, '$') != NULL || strchr(args, '%') != NULL) {
+		opts.flags |= PROCESS_CREATE_SUBSHELL;
+	}
 
 	log_debug("process_new: %s %s 0x%08x", path, args, flags);
 

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -252,7 +252,7 @@ sys_process_execute(struct tlv_handler_ctx *ctx)
 	struct process_options opts = {
 		.process_name = path,
 		.args = args,
-		.flags = PROCESS_CREATE_SUBSHELL
+		.flags = flags,
 	};
 
 	log_debug("process_new: %s %s 0x%08x", path, args, flags);


### PR DESCRIPTION
This appears to fix a bug where we end up calling `/bin/sh -c /bin/sh` when the user uses the `meterpreter > shell` command. e.g:
Before:
```
pstree -ac
  │   ├─bash,17873
  │   │   └─met,30639
  │   │       └─sh,30672 -c /bin/sh
  │   │           └─sh,30673
```
After:
```
meterpreter > getpid
Current pid: 30270
meterpreter > shell
Process 30327 created.
Channel 1 created.

pstree -ac
  │   ├─bash,17873
  │   │   └─met,30270
  │   │       └─sh,30327
```
This also fixes `meterpreter > execute -c -i -f blah` on iOS.
I've only tested on iOS and Linux, so it's unclear if this has unwanted side-effects.