### PR TITLE
Remove unused expression when not using libreflect

### DIFF
--- a/mettle/src/process.h
+++ b/mettle/src/process.h
@@ -7,7 +7,7 @@
 #if HAVE_REFLECT
 #include <reflect.h>
 #else
-#define reflect_execv (void *)
+#define reflect_execv(...) ((void *) -1)
 #endif
 
 struct process;


### PR DESCRIPTION
We don't want to leave extra expressions hanging around for all those `-Werror` compilers.

Verification
========

- [x] Building mettle with compiler that complains about unused expressions succeeds without using libreflect
- [x] Building other configurations works as before