### PR TITLE
fix extapi_clipboard on ios

### DIFF
--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -20,6 +20,7 @@ case $host_os in
 		OBJCFLAGS="$OBJCFLAGS -fobjc-arc"
 		AC_DEFINE(HAVE_WEBCAM)
 		AC_DEFINE(HAVE_AUDIO_OUTPUT)
+		AC_DEFINE(HAVE_CLIPBOARD)
 		AC_SUBST([PLATFORM_LDADD], ['-framework CoreMedia -framework QuartzCore -framework AVFoundation -framework ImageIO'])
 		AC_EGREP_CPP(yes,
 			[#import <TargetConditionals.h>
@@ -29,7 +30,6 @@ case $host_os in
 			],
 			[HOST_OS=osx
 			 AC_DEFINE(HAVE_DESKTOP_SCREENSHOT)
-			 AC_DEFINE(HAVE_CLIPBOARD)
 			 AC_DEFINE(HAVE_MIC)
 			 AC_SUBST([PLATFORM_LDADD], ["-framework AppKit $PLATFORM_LDADD -framework Cocoa"])],
 			[HOST_OS=ios])

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -57,10 +57,10 @@ if HOST_APPLE
 libmettle_la_SOURCES += stdapi/webcam/apple_webcam.m
 libmettle_la_SOURCES += stdapi/audio/apple_output.m
 libmettle_la_SOURCES += stdapi/audio/posix_output.c
+libmettle_la_SOURCES += stdapi/clipboard/apple_clipboard.m
 endif
 if HOST_OSX
 libmettle_la_SOURCES += stdapi/ui/osx_desktop.m
-libmettle_la_SOURCES += stdapi/clipboard/osx_clipboard.m
 libmettle_la_SOURCES += stdapi/audio/apple_mic.m
 endif
 if HOST_LINUX

--- a/mettle/src/stdapi/clipboard/apple_clipboard.m
+++ b/mettle/src/stdapi/clipboard/apple_clipboard.m
@@ -1,6 +1,10 @@
 #import <AVFoundation/AVFoundation.h>
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIPasteboard.h>
+#else
 #import <AppKit/NSPasteboard.h>
+#endif
 
 #include "tlv.h"
 #include "clipboard.h"
@@ -10,9 +14,14 @@ struct tlv_packet *extapi_clipboard_set_data(struct tlv_handler_ctx *ctx)
   const char* clipboard_text = tlv_packet_get_str(ctx->req, TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT_CONTENT);
   @autoreleasepool {
     NSString *text = [NSString stringWithUTF8String:clipboard_text];
+#if TARGET_OS_IPHONE
+    UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+    [pasteboard setValue: text forPasteboardType: @"public.plain-text"];
+#else
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
     [pasteboard clearContents];
     [pasteboard setString:text forType:@"public.utf8-plain-text"];
+#endif
   }
   return tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 }
@@ -21,8 +30,12 @@ struct tlv_packet *extapi_clipboard_get_data(struct tlv_handler_ctx *ctx)
 {
   struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
   @autoreleasepool {
+#if TARGET_OS_IPHONE
+    NSString* text = [UIPasteboard generalPasteboard].string;
+#else
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
     NSString* text = [pasteboard stringForType:NSPasteboardTypeString];
+#endif
     const char *clipboard_text = (const char *)[text cStringUsingEncoding:NSUTF8StringEncoding];
 
     struct tlv_packet *group = tlv_packet_new(TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT, 0);


### PR DESCRIPTION
Quick fix to support the clipboard API on iOS.

Verification:
```
meterpreter > load extapi
Loading extension extapi...Success.
meterpreter > clipboard_get_data
Text captured at
=================
lol
=================

meterpreter > clipboard_set_text hello
meterpreter > clipboard_get_data
Text captured at
=================
hello
=================
```