### PR TITLE
Fix build issues on MinGW (and some other fixes)

### DIFF
--- a/libreflect/src/memfd_exec.c
+++ b/libreflect/src/memfd_exec.c
@@ -39,7 +39,10 @@ void reflect_mfd_execve(const unsigned char *elf, char **argv, char **env) {
 	}
 
 	out = syscall(SYS_memfd_create, "", MFD_CLOEXEC);
-	ftruncate(out, end);
+	if (ftruncate(out, end) == -1) {
+		dprint("Failed to resize memory file: %s\n", strerror(errno));
+		abort();
+	}
 
 	while (written < end) {
 		l = write(out, elf + written, end - written);

--- a/libreflect/src/memfd_exec.c
+++ b/libreflect/src/memfd_exec.c
@@ -47,7 +47,7 @@ void reflect_mfd_execve(const unsigned char *elf, char **argv, char **env) {
 	while (written < end) {
 		l = write(out, elf + written, end - written);
 		if (l == -1) {
-		  dprint("Failed to write %s: %s\n", strerror(errno));
+		  dprint("Failed to write memory file: %s\n", strerror(errno));
 		  abort();
 		}
 		written += l;

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -25,6 +25,7 @@ endif
 ifneq "$(TARGET)" "native"
     ifneq (,$(findstring musl,$(TARGET)))
         CC=$(TOOLS)/musl-cross/bin/$(TARGET)-gcc
+        CXX=$(TOOLS)/musl-cross/bin/$(TARGET)-g++
         CPP=$(TOOLS)/musl-cross/bin/$(TARGET)-cpp
         AR=$(TOOLS)/musl-cross/bin/$(TARGET)-ar
         LD=$(TOOLS)/musl-cross/bin/$(TARGET)-ld

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -32,6 +32,7 @@ ifneq "$(TARGET)" "native"
     endif
     ifneq (,$(findstring mingw,$(TARGET)))
         CC=$(TARGET)-gcc
+        CXX=$(TARGET)-g++
         CPP=$(TARGET)-cpp
         AR=$(TARGET)-ar
         LD=$(TARGET)-ld

--- a/mettle/src/console.c
+++ b/mettle/src/console.c
@@ -128,11 +128,13 @@ static void set_prompt(const char *fmt, ...)
 {
 	char *prompt = NULL;
 	va_list va;
+	int formatted = 0;
+
 	va_start(va, fmt);
-	vasprintf(&prompt, fmt, va);
+	formatted = vasprintf(&prompt, fmt, va);
 	va_end(va);
 
-	if (prompt) {
+	if (formatted >= 0 && prompt) {
 		free(console.prompt);
 		console.prompt = prompt;
 	}
@@ -153,9 +155,11 @@ static void set_prompt(const char *fmt, ...)
 static void console_log(const char *prefix, const char *fmt, va_list va)
 {
 	char *msg = NULL;
-	vasprintf(&msg, fmt, va);
+	int formatted = 0;
 
-	if (msg) {
+	formatted = vasprintf(&msg, fmt, va);
+
+	if (formatted >= 0 && msg) {
 		pthread_mutex_lock(&console.mutex);
 		if (console.thread == pthread_self()) {
 			printf("%s%s\n", prefix, msg);

--- a/mettle/src/json.h
+++ b/mettle/src/json.h
@@ -11,6 +11,8 @@
 #include <json-c/json.h>
 #include "bufferev.h"
 
+#include "printf_format.h"
+
 /*
  * JSON read and dispatch methods
  */
@@ -35,7 +37,7 @@ void json_read_buffer_queue_cb(struct buffer_queue *queue, struct json_tokener *
 int json_add_str(struct json_object *json, const char *key, const char *val);
 
 int json_add_str_fmt(struct json_object *json, const char *key, const char *format, ...)
-	__attribute__((format(printf, 3, 4)));
+	__attribute__((format(METTLE_PRINTF_FORMAT, 3, 4)));
 
 int json_add_int32(struct json_object *json, const char *key, int32_t val);
 

--- a/mettle/src/log.h
+++ b/mettle/src/log.h
@@ -5,6 +5,8 @@
 #ifndef _LOG_H_
 #define _LOG_H_
 
+#include "printf_format.h"
+
 /*
  * Disable logging at all log sites
  */
@@ -99,11 +101,11 @@ void zlog_flush_buffer();
 
 // log an entry; using the printf format
 void zlogf(char const *fmt, ...)
-	__attribute__ ((format(printf, 1, 2)));
+	__attribute__ ((format(METTLE_PRINTF_FORMAT, 1, 2)));
 
 // log an entry with a timestamp
 void zlogf_time(char const *fmt, ...)
-	__attribute__ ((format(printf, 1, 2)));
+	__attribute__ ((format(METTLE_PRINTF_FORMAT, 1, 2)));
 
 void zlog_hex(const char *filename, int line, const void *buf, size_t len);
 
@@ -111,10 +113,10 @@ void zlog_hex(const char *filename, int line, const void *buf, size_t len);
 //   the first 2 arguments can be replaced by ZLOG_LOC which
 //   will be filled by the compiler
 void zlog(const char *filename, int line, char const *fmt, ...)
-	__attribute__ ((format(printf, 3, 4)));
+	__attribute__ ((format(METTLE_PRINTF_FORMAT, 3, 4)));
 
 // log an entry with the filename and location with a timestamp
 void zlog_time(const char *filename, int line, char const *fmt, ...)
-	__attribute__ ((format(printf, 3, 4)));
+	__attribute__ ((format(METTLE_PRINTF_FORMAT, 3, 4)));
 
 #endif

--- a/mettle/src/printf_format.h
+++ b/mettle/src/printf_format.h
@@ -1,0 +1,22 @@
+#ifndef PRINTF_FORMAT_H
+#define PRINTF_FORMAT_H
+
+/*
+ * __MINGW_PRINTF_FORMAT is controlled by the __USE_MINGW_ANSI_STDIO macro and
+ * provides the format archetype to check for. We have to match our
+ * __attribute__ ((format (...))) declarations to MinGW's ANSI layer to avoid
+ * triggering -Wformat on C99 formats not natively in Windows, like %z and %ll.
+ *
+ * Pulling in MinGW's stdio.h will set all the macros we need to make set
+ * things up.
+ */
+
+#include <stdio.h>
+
+#ifdef __MINGW_PRINTF_FORMAT
+#  define METTLE_PRINTF_FORMAT __MINGW_PRINTF_FORMAT
+#else
+#  define METTLE_PRINTF_FORMAT printf
+#endif
+
+#endif

--- a/mettle/src/process_win.c
+++ b/mettle/src/process_win.c
@@ -228,6 +228,13 @@ struct process * process_create_from_executable(struct procmgr *mgr,
 	return process_create(mgr, file, NULL, 0, opts);
 }
 
+struct process * process_create_from_executable_buf(struct procmgr *mgr,
+	const unsigned char *exe, struct process_options *opts)
+{
+	/* TODO: reflective loading not implemented for PEs */
+	return NULL;
+}
+
 struct process * process_create_from_binary_image(struct procmgr *mgr,
 	const unsigned char *bin_image, size_t bin_image_len,
 	struct process_options *opts)

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -16,6 +16,8 @@
 #include "buffer_queue.h"
 #include "tlv_types.h"
 
+#include "printf_format.h"
+
 #define SESSION_GUID_LEN 16
 #define TLV_PREPEND_LEN 24
 #define TLV_MIN_LEN 8
@@ -87,7 +89,7 @@ struct tlv_packet * tlv_packet_add_str(struct tlv_packet *p,
 
 struct tlv_packet * tlv_packet_add_fmt(struct tlv_packet *p,
 		uint32_t type, char const *fmt, ...)
-		__attribute__ ((format(printf, 3, 4)));
+		__attribute__ ((format(METTLE_PRINTF_FORMAT, 3, 4)));
 
 struct tlv_packet * tlv_packet_add_u32(struct tlv_packet *p,
 		uint32_t type, uint32_t val);

--- a/mettle/src/utstring.h
+++ b/mettle/src/utstring.h
@@ -39,6 +39,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdarg.h>
 
+#include "printf_format.h"
+
 #ifndef oom
 #define oom() exit(-1)
 #endif
@@ -146,7 +148,7 @@ _UNUSED_ static void utstring_printf_va(UT_string *s, const char *fmt, va_list a
 #ifdef __GNUC__
 /* support printf format checking (2=the format string, 3=start of varargs) */
 static void utstring_printf(UT_string *s, const char *fmt, ...)
-  __attribute__ (( format( printf, 2, 3) ));
+  __attribute__ (( format( METTLE_PRINTF_FORMAT, 2, 3) ));
 #endif
 _UNUSED_ static void utstring_printf(UT_string *s, const char *fmt, ...) {
    va_list ap;


### PR DESCRIPTION
This fixes a few issues that we had with MinGW compatibility, checks some return values, and sets the `CXX` environment variable when cross compiling (required at the very least for MinGW libsigar).

Verification
========
- [ ] `make i686-w64-mingw32.build` completes successfully (requires a MinGW gcc and g++)
- [ ] `make` (the native build) completes successfully on a system with an updated gcc (8.2+)