### PR TITLE
update S3 bucket to use hostname based access

### DIFF
--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -217,7 +217,7 @@ coreutils: $(TOOLS)/bin/install
 
 musl-cross-$(BUILD_HOST)-$(TOOLCHAIN_VERSION).tar.xz:
 	@echo "Downloading toolchain"
-	curl -f -O https://s3.amazonaws.com/muslcross/musl-cross-$(BUILD_HOST)-$(TOOLCHAIN_VERSION).tar.xz
+	curl -f -O https://muslcross.s3.amazonaws.com/musl-cross-$(BUILD_HOST)-$(TOOLCHAIN_VERSION).tar.xz
 
 $(TOOLS)/musl-cross/.unpacked: musl-cross-$(BUILD_HOST)-$(TOOLCHAIN_VERSION).tar.xz
 	@echo "Unpacking toolchain"


### PR DESCRIPTION
Update to 2020 standard outlined here:

https://forums.aws.amazon.com/ann.jspa?annID=6776

> Amazon S3 currently supports two request URI styles in all regions: path-style (also known as V1) that includes bucket name in the path of the URI (example: //s3.amazonaws.com/<bucketname>/key), and virtual-hosted style (also known as V2) which uses the bucket name as part of the domain name (example: //<bucketname>.s3.amazonaws.com/key). In our effort to continuously improve customer experience, the path-style naming convention is being retired in favor of virtual-hosted style request format. Customers should update their applications to use the virtual-hosted style request format when making S3 API requests before September 30th, 2020 to avoid any service disruptions. Customers using the AWS SDK can upgrade to the most recent version of the SDK to ensure their applications are using the virtual-hosted style request format. 

> Virtual-hosted style requests are supported for all S3 endpoints in all AWS regions. S3 will stop accepting requests made using the path-style request format in all regions starting September 30th, 2020. Any requests using the path-style request format made after this time will fail.

> If there is any reason why your application is not able to utilize the virtual-hosted style request format, or if you have any questions or concerns, please reach out to AWS Support.