### PR TITLE
don't dereference channel if it got EOF'd by Metasploit

### DIFF
--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -211,11 +211,13 @@ static void process_channel_exit_cb(struct process *p, int exit_status, void *ar
 	struct channelmgr_ctx *cm_ctx = arg;
 	struct channel *c = channelmgr_channel_by_id(cm_ctx->cm, cm_ctx->channel_id);
 	cm_ctx->eof = true;
-	if (c && channel_get_interactive(c)) {
-		channel_send_close_request(c);
-		free(cm_ctx);
-	} else {
-		channel_set_eof(c);
+	if (c) {
+	   if (channel_get_interactive(c)) {
+			channel_send_close_request(c);
+			free(cm_ctx);
+		} else {
+			channel_set_eof(c);
+		}
 	}
 }
 

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -212,7 +212,7 @@ static void process_channel_exit_cb(struct process *p, int exit_status, void *ar
 	struct channel *c = channelmgr_channel_by_id(cm_ctx->cm, cm_ctx->channel_id);
 	cm_ctx->eof = true;
 	if (c) {
-	   if (channel_get_interactive(c)) {
+		if (channel_get_interactive(c)) {
 			channel_send_close_request(c);
 			free(cm_ctx);
 		} else {


### PR DESCRIPTION
Move the check to see if the channel still exists around all dereferences. Note that the original cause of this fix was some code intended to make Metasploit work a little better with the channel API being too fast to succeed in Mettle 542a4d14338bc19db4c07e40824e4af85814b74b, but there are probably some fundamental channel issues we should look at improving from the interface level too.

Check that this sequence doesn't crash meterpreter:

```
meterpreter > shell
Process 24998 created.
Channel 1 created.
^Z
Background channel 1? [y/N]  y
meterpreter > channel -c 1
[*] Closed channel 1.
meterpreter >
```