### PR TITLE
startup mettle with a sane environment on start

### DIFF
--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -250,6 +250,8 @@ struct mettle *mettle(void)
 
 	m->pm = procmgr_new(m->loop);
 
+	procmgr_setup_env();
+
 	m->em = extmgr_new();
 
 	sigar_fqdn_get(m->sigar, m->fqdn, sizeof(m->fqdn));

--- a/mettle/src/process.h
+++ b/mettle/src/process.h
@@ -15,6 +15,8 @@ struct progmgr;
 
 struct procmgr * procmgr_new(struct ev_loop *loop);
 
+void procmgr_setup_env(void);
+
 void procmgr_free(struct procmgr *mgr);
 
 typedef void (*process_exit_cb_t)(struct process *, int exit_status, void *arg);

--- a/mettle/src/process_win.c
+++ b/mettle/src/process_win.c
@@ -156,6 +156,10 @@ void process_set_callbacks(struct process *p,
 	p->cb_arg = cb_arg;
 }
 
+void procmgr_setup_env(void)
+{
+}
+
 struct process * process_create(struct procmgr *mgr,
 	const char *file,
 	const unsigned char *bin_image, size_t bin_image_len,


### PR DESCRIPTION
In staged payloads, mettle on Linux get passed a fake argc/argv/envp.  This means that all staged payloads do not have any environment variables out of the box. This inconsistency can lead to post modules working incorrectly. This commit moves the environment fixup code that was already present when spawning child processes into the parent process. That way, the child processes simply inherit, and it's possible to inspect what the environment will be earlier in the boot process.

## Verification Steps
 - [ ] From this directory, assuming you know how to build mettle and test it `make x86_64-linux-musl.install`
 - [ ] Generate a staged payload `./msfvenom -p linux/x64/meterpreter/reverse_tcp -f elf -o test.elf lhost=127.0.0.1`
 - [ ] Then from metasploit, stage the payload and run the get_env test from the session:
```
payload => linux/x64/meterpreter/reverse_tcp
lhost => 127.0.0.1
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
WARNING: Local file /home/bcook/projects/metasploit-framework/data/mettle/x86_64-linux-musl/bin/mettle.bin is being used
WARNING: Local files may be incompatible Metasploit framework
[*] Sending stage (3021284 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:51872) at 2019-05-21 03:29:01 -0500

meterpreter > background 
[*] Backgrounding session 1...
msf5 exploit(multi/handler) > loadpath test/modules
Loaded 35 modules:
    10 post modules
    13 exploit modules
    12 auxiliary modules
msf5 exploit(multi/handler) > use post/test/get_env 
msf5 post(test/get_env) > set session 1
session => 1
msf5 post(test/get_env) > run

[*] Running against session 1
[*] Session type is meterpreter and platform is linux
[+] should return user
[+] should handle $ sign
[+] should return multiple envs
[*] Passed: 3; Failed: 0
[*] Post module execution completed
```
