### PR TITLE
add 64-bit Windows builds

### DIFF
--- a/ARCHES
+++ b/ARCHES
@@ -1,4 +1,5 @@
 i686-w64-mingw32
+x86_64-w64-mingw32
 x86_64-linux-musl
 i486-linux-musl
 aarch64-linux-musl


### PR DESCRIPTION
This enables the 64-bit mingw builds so we can verify they continue compiling (not sure if it actually works IRL, YMMV).