### PR TITLE
Send socket information when opening channels

### DIFF
--- a/mettle/src/bufferev.c
+++ b/mettle/src/bufferev.c
@@ -7,7 +7,6 @@
 #include <ev.h>
 #include <eio.h>
 #include <errno.h>
-#include <string.h>
 #include <strings.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -17,7 +16,6 @@
 #include <netdb.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <arpa/inet.h>
 #include <sys/uio.h>
 
 #include "buffer_queue.h"
@@ -322,24 +320,6 @@ int bufferev_connect_tcp_sock(struct bufferev *be, int sock)
 	}
 
 	return 0;
-}
-
-static char *
-parse_sockaddr(struct sockaddr_storage *addr, uint16_t *port)
-{
-	char host[INET6_ADDRSTRLEN] = { 0 };
-
-	if (addr->ss_family == AF_INET) {
-		struct sockaddr_in *s = (struct sockaddr_in *)addr;
-		*port = ntohs(s->sin_port);
-		inet_ntop(AF_INET, &s->sin_addr, host, INET6_ADDRSTRLEN);
-	} else if (addr->ss_family == AF_INET6) {
-		struct sockaddr_in6 *s = (struct sockaddr_in6 *)addr;
-		*port = ntohs(s->sin6_port);
-		inet_ntop(AF_INET6, &s->sin6_addr, host, INET6_ADDRSTRLEN);
-	}
-
-	return strdup(host);
 }
 
 char * bufferev_get_udp_msg_peer_addr(struct bufferev_udp_msg *msg, uint16_t *port)

--- a/mettle/src/network_server.c
+++ b/mettle/src/network_server.c
@@ -154,5 +154,14 @@ void network_server_free(struct network_server *ns)
 	}
 }
 
+char * network_server_get_local_addr(struct network_server *ns, uint16_t *port)
+{
+	struct sockaddr_storage addr;
+	socklen_t len = sizeof(addr);
 
+	if (getsockname(ns->listener, (struct sockaddr *)&addr, &len) == -1) {
+		return NULL;
+	}
 
+	return parse_sockaddr(&addr, port);
+}

--- a/mettle/src/network_server.h
+++ b/mettle/src/network_server.h
@@ -25,4 +25,6 @@ void network_server_setcbs(struct network_server *ns,
 
 void network_server_free(struct network_server *ns);
 
+char * network_server_get_local_addr(struct network_server *ns, uint16_t *port);
+
 #endif

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -49,6 +49,14 @@ tcp_client_channel_event_cb(struct bufferev *be, int event, void *arg)
 
 		if (event & BEV_CONNECTED) {
 			p = tlv_packet_response_result(tlv_ctx, TLV_RESULT_SUCCESS);
+			uint16_t local_port;
+			char *local_host = bufferev_get_local_addr(be, &local_port);
+			if (local_host) {
+				p = tlv_packet_add_str(p, TLV_TYPE_LOCAL_HOST, local_host);
+				p = tlv_packet_add_u32(p, TLV_TYPE_LOCAL_PORT, local_port);
+				free(local_host);
+				local_host = NULL;
+			}
 			channel_opened(tcc->channel);
 
 		} else if (event & BEV_ERROR) {
@@ -236,6 +244,14 @@ udp_client_channel_event_cb(struct bufferev *be, int event, void *arg)
 
 		if (event & BEV_CONNECTED) {
 			p = tlv_packet_response_result(tlv_ctx, TLV_RESULT_SUCCESS);
+			uint16_t local_port;
+			char *local_host = bufferev_get_local_addr(be, &local_port);
+			if (local_host) {
+				p = tlv_packet_add_str(p, TLV_TYPE_LOCAL_HOST, local_host);
+				p = tlv_packet_add_u32(p, TLV_TYPE_LOCAL_PORT, local_port);
+				free(local_host);
+				local_host = NULL;
+			}
 			channel_opened(tcc->channel);
 
 		} else if (event & BEV_ERROR) {

--- a/mettle/src/util.c
+++ b/mettle/src/util.c
@@ -6,6 +6,9 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #endif
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
 
 #include "util.h"
 
@@ -31,3 +34,20 @@ make_socket_nonblocking(int fd)
 	return 0;
 }
 
+char *
+parse_sockaddr(struct sockaddr_storage *addr, uint16_t *port)
+{
+	char host[INET6_ADDRSTRLEN] = { 0 };
+
+	if (addr->ss_family == AF_INET) {
+		struct sockaddr_in *s = (struct sockaddr_in *)addr;
+		*port = ntohs(s->sin_port);
+		inet_ntop(AF_INET, &s->sin_addr, host, INET6_ADDRSTRLEN);
+	} else if (addr->ss_family == AF_INET6) {
+		struct sockaddr_in6 *s = (struct sockaddr_in6 *)addr;
+		*port = ntohs(s->sin6_port);
+		inet_ntop(AF_INET6, &s->sin6_addr, host, INET6_ADDRSTRLEN);
+	}
+
+	return strdup(host);
+}

--- a/mettle/src/util.h
+++ b/mettle/src/util.h
@@ -7,6 +7,8 @@
 #ifndef _UTIL_H_
 #define _UTIL_H_
 
+#include <sys/socket.h>
+
 /*
  * COUNT_OF from Google Chromium, deals with C++ objects
  */
@@ -26,5 +28,8 @@
 		  _a < _b ? _a : _b; })
 
 int make_socket_nonblocking(int fd);
+
+char *
+parse_sockaddr(struct sockaddr_storage *addr, uint16_t *port);
 
 #endif


### PR DESCRIPTION
This PR updates the channel opening behavior for TCP client, server and UDP channels to echo the local socket information back to metasploit. This is notably useful to know what local port the socket is bound to when metasploit specified the value of `0` causing the socket to use an available one selected by the OS.

Changes to the framework to consume this information and offer meaningful testing steps are forthcoming.