### PR TITLE
Change from PEM to DER for crypt TLV negotiation

### DIFF
--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -103,7 +103,7 @@ static struct tlv_packet *core_negotiate_tlv_encryption(struct tlv_handler_ctx *
 	struct mettle *m = ctx->arg;
 	struct tlv_dispatcher *td = mettle_get_tlv_dispatcher(m);
 	char *guid = tlv_packet_get_raw(ctx->req, TLV_TYPE_SESSION_GUID, &guid_len);
-	unsigned char *pkey = tlv_packet_get_raw(ctx->req, TLV_TYPE_RSA_PUB_KEY, &pkey_len);;
+	unsigned char *pkey = tlv_packet_get_raw(ctx->req, TLV_TYPE_RSA_PUB_KEY, &pkey_len);
 
 	if (pkey_len > 0) {
 		struct tlv_encryption_ctx* enc_ctx = create_tlv_encryption_context(ENC_AES256);

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -494,7 +494,7 @@ int tlv_dispatcher_add_handler(struct tlv_dispatcher *td,
 	handler->command_id = command_id;
 	handler->cb = cb;
 	handler->arg = arg;
-  log_debug("Registering command %u, cb %p, arg %p", command_id, cb, arg);
+	log_debug("Registering command %u, cb %p, arg %p", command_id, cb, arg);
 
 	HASH_ADD_INT(td->handlers, command_id, handler);
 	return 0;
@@ -521,7 +521,7 @@ static struct tlv_handler * find_handler(struct tlv_dispatcher *td, uint32_t com
 {
 	struct tlv_handler *handler = NULL;
 	HASH_FIND_INT(td->handlers, &command_id, handler);
-  log_debug("Handler for %u: %p", command_id, handler);
+	log_debug("Handler for %u: %p", command_id, handler);
 	return handler;
 }
 

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -25,7 +25,7 @@
 // NOTE: It's important that if we continue to use this method to determine
 // if there's a packet on the wire that we update this value otherwise mettle
 // will fail to stage.
-#define PACKET_LENGTH_CORE_NEGOTIATE_TLV_ENCRYPTION 545
+#define PACKET_LENGTH_CORE_NEGOTIATE_TLV_ENCRYPTION 387
 #define EXPECTED_FIRST_PACKET_LEN PACKET_LENGTH_CORE_NEGOTIATE_TLV_ENCRYPTION
 #define EXPECTED_FIRST_PACKET_BODY_LEN (EXPECTED_FIRST_PACKET_LEN - TLV_PREPEND_LEN)
 

--- a/mettle/src/tlv_types.h
+++ b/mettle/src/tlv_types.h
@@ -96,7 +96,7 @@
 #define TLV_TYPE_UUID                  (TLV_META_TYPE_RAW     | 461)
 #define TLV_TYPE_SESSION_GUID          (TLV_META_TYPE_RAW     | 462)
 
-#define TLV_TYPE_RSA_PUB_KEY           (TLV_META_TYPE_STRING  | 550)
+#define TLV_TYPE_RSA_PUB_KEY           (TLV_META_TYPE_RAW     | 550)
 #define TLV_TYPE_SYM_KEY_TYPE          (TLV_META_TYPE_UINT    | 551)
 #define TLV_TYPE_SYM_KEY               (TLV_META_TYPE_RAW     | 552)
 #define TLV_TYPE_ENC_SYM_KEY           (TLV_META_TYPE_RAW     | 553)


### PR DESCRIPTION
We're now pushing RSA keys across as DER instead of PEM. Associated Metasploit PR with all the detail is [over here](https://github.com/rapid7/metasploit-framework/pull/13400).

# IMPORTANT

NOTE: we'll need to update the "first packet detection" code to match the new packet size when this lands. For more information please see [this commit](https://github.com/rapid7/mettle/pull/196/commits/db60c8f7a798138876a00f3de06be87b1a619708)