### PR TITLE
more fix username in session info

### DIFF
--- a/mettle/src/stdapi/sys/config.c
+++ b/mettle/src/stdapi/sys/config.c
@@ -12,7 +12,9 @@
 #include <mettle.h>
 #include <sigar.h>
 #include <time.h>
+#ifndef _WIN32
 #include <pwd.h>
+#endif
 
 #include "log.h"
 #include "tlv.h"


### PR DESCRIPTION
Fix #198 which fixed #190 to ensure all targets can compile.

Fixes the following compile error:
```
08:12:44 Building mettle for i686-w64-mingw32
08:12:44 make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
08:13:02 In file included from /mettle/mettle/src/stdapi/stdapi.c:13:0
08:13:02 /mettle/mettle/src/stdapi/sys/config.c:15:17: fatal error: pwd.h: No such file or directory
08:13:02 compilation terminated.
08:13:02 make[2]: *** [stdapi/stdapi.lo] Error 1
08:13:02 make[1]: *** [install-recursive] Error 1
08:13:02 make/Makefile.mettle:68: recipe for target '/mettle/build/i686-w64-mingw32/bin/mettle.built' failed
08:13:02 make: *** [/mettle/build/i686-w64-mingw32/bin/mettle.built] Error 2
08:13:02 Failed to build i686-w64-mingw32
```

### Verification

Ensure all targets cross compiled by in linux toolchains complete.  