### PR TITLE
add sha1 armv7 signing as a platform application

### DIFF
--- a/deps/ent.xml
+++ b/deps/ent.xml
@@ -1,0 +1,6 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+        <dict>
+                <key>platform-application</key> <true/>
+        </dict>
+</plist>

--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -80,6 +80,9 @@ $(BUILD)/bin/mettle.dylib: $(BUILD)/bin/mettle.built
 $(BUILD)/bin/mettle.sha1.dylib: $(BUILD)/bin/mettle.built
 	@./deps/app2dylib -o $(BUILD)/bin/mettle.sha1.dylib $(BUILD)/bin/mettle
 	@./deps/ldid -S $(BUILD)/bin/mettle.sha1.dylib
+ifneq (,$(findstring arm-iphone,$(BUILD)))
+	@./deps/ldid -Sdeps/ent.xml $(BUILD)/bin/mettle
+endif
 
 mettle: $(BUILD)/bin/mettle.built $(METTLE_TARGETS)
 


### PR DESCRIPTION
This is a requirement for https://github.com/rapid7/metasploit-framework/pull/13911
In order to to posix_spawn a meterpreter payload it must be (self) signed as a platform application.
The signature is broken when we overwrite the LHOST/LPORT arguments, but the kernel exploit ensures this doesn't matter (as long as the binary has a platform application signature, even if it's invalid/self signed.