### PR TITLE
Check for valid channel context before reading and writing

### DIFF
--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -156,6 +156,10 @@ static ssize_t
 tcp_client_read(struct channel *c, void *buf, size_t len)
 {
 	struct tcp_client_channel *tcc = channel_get_ctx(c);
+	if (tcc == NULL) {
+		errno = EIO;
+		return -1;
+	}
 	return network_client_read(tcc->nc, buf, len);
 }
 
@@ -163,6 +167,10 @@ static ssize_t
 tcp_client_write(struct channel *c, void *buf, size_t len)
 {
 	struct tcp_client_channel *tcc = channel_get_ctx(c);
+	if (tcc == NULL) {
+		errno = EIO;
+		return -1;
+	}
 	return network_client_write(tcc->nc, buf, len);
 }
 
@@ -332,8 +340,12 @@ err:
 static ssize_t
 udp_client_read(struct channel *c, void *buf, size_t len)
 {
-	struct udp_client_channel *ucc = channel_get_ctx(c);
 	size_t msg_len;
+	struct udp_client_channel *ucc = channel_get_ctx(c);
+	if (ucc == NULL) {
+		errno = EIO;
+		return -1;
+	}
 	void *msg_buf = network_client_read_msg(ucc->nc, &msg_len);
 	memcpy(buf, msg_buf, TYPESAFE_MIN(len, msg_len));
 	return msg_len;
@@ -343,6 +355,10 @@ static ssize_t
 udp_client_write(struct channel *c, void *buf, size_t len)
 {
 	struct udp_client_channel *ucc = channel_get_ctx(c);
+	if (ucc == NULL) {
+		errno = EIO;
+		return -1;
+	}
 	return network_client_write(ucc->nc, buf,
 			TYPESAFE_MIN(len, IP_LEN_MAX - IP_HDR_LEN - UDP_HDR_LEN));
 }

--- a/mettle/src/stdapi/net/server.c
+++ b/mettle/src/stdapi/net/server.c
@@ -161,12 +161,20 @@ static int tcp_server_free(struct channel *c)
 static ssize_t tcp_conn_read(struct channel *c, void *buf, size_t len)
 {
 	struct tcp_server_conn *conn = channel_get_ctx(c);
+	if (conn == NULL) {
+		errno = EIO;
+		return -1;
+	}
 	return bufferev_read(conn->be, buf, len);
 }
 
 static ssize_t tcp_conn_write(struct channel *c, void *buf, size_t len)
 {
 	struct tcp_server_conn *conn = channel_get_ctx(c);
+	if (conn == NULL) {
+		errno = EIO;
+		return -1;
+	}
 	return bufferev_write(conn->be, buf, len);
 }
 


### PR DESCRIPTION
This fixes a bug found while investigating rapid7/metasploit-framework#14506. Basically sometimes while under a heavy throughput load, mettle will encounter an instance where it attempts to write to a TCP channel with a context that was previously set to `NULL` from within `tcp_client_channel_event_cb` due to either a `BEV_EOF` or `BEV_ERROR` event occurring. I tested this quite a few times and while reproducing it wasn't consistent, it was the only issue I ran into.

For testing this, I used `gdb` and ensure I could reproduce the original issue where the context returned from `channel_get_ctx` was NULL and that when I resumed the debugger it **did not** crash.

* [ ] Build mettle
* [ ] Start the binary under GDB
* [ ] Run it using `run --debug 3 -u tcp://YOURIP:4444/` where _YOURIP_ is the IP address of metasploit with a running listener
* [ ] Once you have a session established to metasploit set the breakpoint with the condition `if $rax == 0`
    * Example:

    ```
    (gdb) disassemble tcp_client_write
    Dump of assembler code for function tcp_client_write:
       0x00007ffff7d34f72 <+0>:	sub    rsp,0x18
       0x00007ffff7d34f76 <+4>:	mov    QWORD PTR [rsp+0x8],rsi
       0x00007ffff7d34f7b <+9>:	mov    QWORD PTR [rsp],rdx
       0x00007ffff7d34f7f <+13>:	call   0x7ffff7d2b25c <channel_get_ctx>
       0x00007ffff7d34f84 <+18>:	test   rax,rax
       0x00007ffff7d34f87 <+21>:	mov    rdx,QWORD PTR [rsp]
       0x00007ffff7d34f8b <+25>:	mov    rsi,QWORD PTR [rsp+0x8]
       0x00007ffff7d34f90 <+30>:	je     0x7ffff7d34f9f <tcp_client_write+45>
       0x00007ffff7d34f92 <+32>:	mov    rdi,QWORD PTR [rax+0x8]
       0x00007ffff7d34f96 <+36>:	add    rsp,0x18
       0x00007ffff7d34f9a <+40>:	jmp    0x7ffff7d30da2 <network_client_write>
       0x00007ffff7d34f9f <+45>:	call   0x7ffff7da792c <__errno_location>
       0x00007ffff7d34fa4 <+50>:	mov    DWORD PTR [rax],0x5
       0x00007ffff7d34faa <+56>:	or     rax,0xffffffffffffffff
       0x00007ffff7d34fae <+60>:	add    rsp,0x18
       0x00007ffff7d34fb2 <+64>:	ret    
    End of assembler dump.
    (gdb) break *0x00007ffff7d34f84 if $rax == 0
    Breakpoint 1 at 0x7ffff7d34f84
    ```
- [ ] Use the SOCKS proxy module to put a decent load through the Meterpreter instance, the debug logs should show that the traffic is being properly tunneled
    * This part takes some patience and luck, I loaded multiple news and social media sites all at once to try and reproduce it and just spammed F5 for a while
- [ ] Whether or not you set the breakpoint to validate the condition, you should **not get a crash in mettle**

<details>
<summary>Stack Trace 1</summary>

**Note that this includes debug logs that I omitted from the PR**

```
[12-21-2020 16:37:01.266s] [network_client.c:345] connecting to tcp://104.244.39.20:443
[12-21-2020 16:37:01.269s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.269s] [tlv.c:565] processing command: '8' id: '74597481087560927310809518476624'
[12-21-2020 16:37:01.269s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:01.269s] [tlv.c:565] processing command: '1' id: '00624309952798723135906306628687'
[12-21-2020 16:37:01.269s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff8008a80
[12-21-2020 16:37:01.269s] [channel.c:110] setting channel context for 0x7ffff8008a80 to NULL
[12-21-2020 16:37:01.277s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.277s] [tlv.c:565] processing command: '8' id: '09639615477468674955917072759659'
[12-21-2020 16:37:01.281s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.281s] [tlv.c:565] processing command: '8' id: '01810569096862595612090191374991'
[12-21-2020 16:37:01.281s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:01.281s] [tlv.c:565] processing command: '1' id: '94913189702919267708821707032986'
[12-21-2020 16:37:01.281s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff8091a60
[12-21-2020 16:37:01.281s] [channel.c:110] setting channel context for 0x7ffff8091a60 to NULL
[12-21-2020 16:37:01.288s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.288s] [tlv.c:565] processing command: '8' id: '78132016770633971123341425711149'
[12-21-2020 16:37:01.293s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.293s] [tlv.c:565] processing command: '8' id: '24306664729099518732555831862694'
[12-21-2020 16:37:01.299s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:01.299s] [tlv.c:565] processing command: '4' id: '52199690485581496817760142468403'
[12-21-2020 16:37:01.299s] [channel.c:108] setting channel context for 0x7ffff800c5e0 to 0x7ffff80077a0
[12-21-2020 16:37:01.299s] [network_client.c:467] resolving 'tcp://px.moatads.com:443'
[12-21-2020 16:37:01.305s] [network_client.c:345] connecting to tcp://23.35.74.249:443
[12-21-2020 16:37:01.314s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.314s] [tlv.c:565] processing command: '8' id: '45499933046988362256721521924358'
[12-21-2020 16:37:01.314s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.314s] [tlv.c:565] processing command: '8' id: '34972683088397560684354915442684'
[12-21-2020 16:37:01.332s] [network_client.c:278] connected to 'tcp://px.moatads.com:443'
[12-21-2020 16:37:01.339s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:01.339s] [tlv.c:565] processing command: '4' id: '61791370114515727935629426220443'
[12-21-2020 16:37:01.339s] [channel.c:108] setting channel context for 0x7ffff8008a80 to 0x7ffff800c480
[12-21-2020 16:37:01.339s] [network_client.c:467] resolving 'tcp://track.celtra.com:443'
[12-21-2020 16:37:01.341s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.341s] [tlv.c:565] processing command: '8' id: '91687706897839943832637893193117'
[12-21-2020 16:37:01.342s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.342s] [tlv.c:565] processing command: '8' id: '31072348865799027085634577672709'
[12-21-2020 16:37:01.342s] [network_client.c:345] connecting to tcp://52.23.86.243:443
[12-21-2020 16:37:01.343s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.343s] [tlv.c:565] processing command: '8' id: '35867366019491924986981129420636'
[12-21-2020 16:37:01.360s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.360s] [tlv.c:565] processing command: '8' id: '40420771247614051176421958361921'
[12-21-2020 16:37:01.360s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:01.360s] [tlv.c:565] processing command: '1' id: '31670180732205913044122079361903'
[12-21-2020 16:37:01.360s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff8007a00
[12-21-2020 16:37:01.360s] [channel.c:110] setting channel context for 0x7ffff8007a00 to NULL
[12-21-2020 16:37:01.364s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.364s] [tlv.c:565] processing command: '8' id: '86939887160031822836224591531632'
[12-21-2020 16:37:01.365s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:01.365s] [tlv.c:565] processing command: '4' id: '25437878762918606844461015014749'
[12-21-2020 16:37:01.365s] [channel.c:108] setting channel context for 0x7ffff8091f80 to 0x7ffff800b340
[12-21-2020 16:37:01.365s] [network_client.c:467] resolving 'tcp://track.celtra.com:443'
[12-21-2020 16:37:01.369s] [network_client.c:345] connecting to tcp://54.159.176.96:443
[12-21-2020 16:37:01.375s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.375s] [tlv.c:565] processing command: '8' id: '15582273371498448136707722577664'
[12-21-2020 16:37:01.375s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.375s] [tlv.c:565] processing command: '8' id: '91187192138400470468031347940124'
[12-21-2020 16:37:01.376s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:01.376s] [tlv.c:565] processing command: '4' id: '54471304660822214359160274961512'
[12-21-2020 16:37:01.376s] [channel.c:108] setting channel context for 0x7ffff8005b00 to 0x7ffff8007300
[12-21-2020 16:37:01.376s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:01.376s] [tlv.c:565] processing command: '4' id: '47279723073057976191226601667186'
[12-21-2020 16:37:01.376s] [channel.c:108] setting channel context for 0x7ffff800c7c0 to 0x7ffff8091e00
[12-21-2020 16:37:01.376s] [network_client.c:278] connected to 'tcp://track.celtra.com:443'
[12-21-2020 16:37:01.376s] [network_client.c:278] connected to 'tcp://dt.adsafeprotected.com:443'
[12-21-2020 16:37:01.376s] [network_client.c:467] resolving 'tcp://pagead2.googlesyndication.com:443'
[12-21-2020 16:37:01.376s] [network_client.c:467] resolving 'tcp://www.summerhamster.com:443'
[12-21-2020 16:37:01.377s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.377s] [tlv.c:565] processing command: '8' id: '31782627237736809513011698132684'
[12-21-2020 16:37:01.382s] [network_client.c:345] connecting to tcp://3.225.151.87:443
[12-21-2020 16:37:01.382s] [network_client.c:345] connecting to tcp://142.250.73.226:443
[12-21-2020 16:37:01.398s] [network_client.c:278] connected to 'tcp://track.celtra.com:443'
[12-21-2020 16:37:01.414s] [network_client.c:278] connected to 'tcp://www.summerhamster.com:443'
[12-21-2020 16:37:01.416s] [network_client.c:278] connected to 'tcp://pagead2.googlesyndication.com:443'
[12-21-2020 16:37:01.704s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.704s] [tlv.c:565] processing command: '8' id: '32228678292711157132387796768340'
[12-21-2020 16:37:01.708s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.708s] [tlv.c:565] processing command: '8' id: '87383021903257410616647528803131'
[12-21-2020 16:37:01.970s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.970s] [tlv.c:565] processing command: '8' id: '50702089920455784700876352731315'
[12-21-2020 16:37:01.971s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:01.971s] [tlv.c:565] processing command: '1' id: '72602520506399506833198273594510'
[12-21-2020 16:37:01.971s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff7fffdc0
[12-21-2020 16:37:01.971s] [channel.c:110] setting channel context for 0x7ffff7fffdc0 to NULL
[12-21-2020 16:37:01.972s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:01.972s] [tlv.c:565] processing command: '1' id: '25487726374728168681069272724899'
[12-21-2020 16:37:01.972s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff8090160
[12-21-2020 16:37:01.972s] [channel.c:110] setting channel context for 0x7ffff8090160 to NULL
[12-21-2020 16:37:01.975s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.975s] [tlv.c:565] processing command: '8' id: '56118691852771482617580176899695'
[12-21-2020 16:37:01.978s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.978s] [tlv.c:565] processing command: '8' id: '37141379847696740009149307611426'
[12-21-2020 16:37:01.988s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:01.988s] [tlv.c:565] processing command: '8' id: '51110360762515621145893159419559'
[12-21-2020 16:37:01.993s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:01.993s] [tlv.c:565] processing command: '4' id: '40004026097941131843230943538115'
[12-21-2020 16:37:01.993s] [channel.c:108] setting channel context for 0x7ffff800c840 to 0x7ffff8091dc0
[12-21-2020 16:37:01.994s] [network_client.c:467] resolving 'tcp://www.cnn.com:443'
[12-21-2020 16:37:01.999s] [network_client.c:345] connecting to tcp://199.232.5.67:443
[12-21-2020 16:37:02.013s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.013s] [tlv.c:565] processing command: '8' id: '16035233918293726331105907911029'
[12-21-2020 16:37:02.013s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.013s] [tlv.c:565] processing command: '8' id: '98678145966531534108516236460778'
[12-21-2020 16:37:02.014s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.014s] [tlv.c:565] processing command: '8' id: '19959898272206262819010385978801'
[12-21-2020 16:37:02.014s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.014s] [tlv.c:565] processing command: '8' id: '65444550906827861662169313238365'
[12-21-2020 16:37:02.014s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.014s] [tlv.c:565] processing command: '8' id: '34627468342327929517674497514615'
[12-21-2020 16:37:02.014s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:02.014s] [tlv.c:565] processing command: '4' id: '68127479822559868042838204778439'
[12-21-2020 16:37:02.014s] [channel.c:108] setting channel context for 0x7ffff8090160 to 0x7ffff8006ba0
[12-21-2020 16:37:02.014s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.014s] [tlv.c:565] processing command: '8' id: '69321542253931363637708223628478'
[12-21-2020 16:37:02.014s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.014s] [tlv.c:565] processing command: '8' id: '88784695049636210353395326614793'
[12-21-2020 16:37:02.015s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.015s] [tlv.c:565] processing command: '8' id: '30437908546364114185794725543696'
[12-21-2020 16:37:02.016s] [network_client.c:467] resolving 'tcp://gurgle.speedtest.net:443'
[12-21-2020 16:37:02.022s] [network_client.c:345] connecting to tcp://35.169.120.16:443
[12-21-2020 16:37:02.026s] [network_client.c:278] connected to 'tcp://www.cnn.com:443'
[12-21-2020 16:37:02.059s] [network_client.c:278] connected to 'tcp://gurgle.speedtest.net:443'
[12-21-2020 16:37:02.500s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.500s] [tlv.c:565] processing command: '8' id: '33141236504574170012237868690676'
[12-21-2020 16:37:02.755s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:02.755s] [tlv.c:565] processing command: '8' id: '20216714200190704014529191289723'
[12-21-2020 16:37:03.664s] [mettle.c:75] Heartbeat
[12-21-2020 16:37:03.729s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:03.729s] [tlv.c:565] processing command: '4' id: '91627904193474473383221066371111'
[12-21-2020 16:37:03.729s] [channel.c:108] setting channel context for 0x7ffff7fffdc0 to 0x7ffff8007a00
[12-21-2020 16:37:03.729s] [network_client.c:467] resolving 'tcp://ads.servenobid.com:443'
[12-21-2020 16:37:03.732s] [network_client.c:345] connecting to tcp://3.227.226.24:443
[12-21-2020 16:37:03.760s] [network_client.c:278] connected to 'tcp://ads.servenobid.com:443'
[12-21-2020 16:37:03.760s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:03.760s] [tlv.c:565] processing command: '8' id: '04817161756955586460768607238614'
[12-21-2020 16:37:03.761s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:03.761s] [tlv.c:565] processing command: '8' id: '91210585872881486944073581609876'
[12-21-2020 16:37:03.761s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:03.761s] [tlv.c:565] processing command: '8' id: '65066467273731836324847885222215'
[12-21-2020 16:37:03.761s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:03.761s] [tlv.c:565] processing command: '1' id: '76991017049486143063515383198860'
[12-21-2020 16:37:03.761s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff80064a0
[12-21-2020 16:37:03.761s] [channel.c:110] setting channel context for 0x7ffff80064a0 to NULL
[12-21-2020 16:37:03.761s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:03.761s] [tlv.c:565] processing command: '8' id: '23964983463016471625053899919523'
[12-21-2020 16:37:03.988s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:03.988s] [tlv.c:565] processing command: '4' id: '23127571630763234287643151649082'
[12-21-2020 16:37:03.988s] [channel.c:108] setting channel context for 0x7ffff800a380 to 0x7ffff800a540
[12-21-2020 16:37:03.988s] [network_client.c:467] resolving 'tcp://ads.servenobid.com:443'
[12-21-2020 16:37:03.991s] [network_client.c:345] connecting to tcp://18.235.230.214:443
[12-21-2020 16:37:04.019s] [network_client.c:278] connected to 'tcp://ads.servenobid.com:443'
[12-21-2020 16:37:04.019s] [tlv.c:524] Handler for 1026: 0x7ffff8004700
[12-21-2020 16:37:04.020s] [tlv.c:565] processing command: '1026' id: '47238689597787288638804494058845'
[12-21-2020 16:37:04.020s] [stdapi/net/client.c:196] shutting down connection for writes
[12-21-2020 16:37:04.755s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:04.755s] [tlv.c:565] processing command: '1' id: '90402251970566062889035393460985'
[12-21-2020 16:37:04.755s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff800b4c0
[12-21-2020 16:37:04.755s] [channel.c:110] setting channel context for 0x7ffff800b4c0 to NULL
[12-21-2020 16:37:04.774s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:04.774s] [tlv.c:565] processing command: '4' id: '73694285138602671879551666512767'
[12-21-2020 16:37:04.774s] [channel.c:108] setting channel context for 0x7ffff800b4c0 to 0x7ffff808ef20
[12-21-2020 16:37:04.774s] [network_client.c:467] resolving 'tcp://c.amazon-adsystem.com:443'
[12-21-2020 16:37:04.777s] [network_client.c:345] connecting to tcp://52.85.73.85:443
[12-21-2020 16:37:04.814s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:04.815s] [tlv.c:565] processing command: '8' id: '10071168524836205960589613921816'
[12-21-2020 16:37:04.820s] [network_client.c:278] connected to 'tcp://c.amazon-adsystem.com:443'
[12-21-2020 16:37:05.435s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:05.435s] [tlv.c:565] processing command: '8' id: '98101565378595707500152887651404'
[12-21-2020 16:37:05.687s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:05.687s] [tlv.c:565] processing command: '8' id: '94761307527054032598850653490747'
[12-21-2020 16:37:05.687s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:05.687s] [tlv.c:565] processing command: '8' id: '48613540839757333203012422439221'
[12-21-2020 16:37:05.687s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:05.687s] [tlv.c:565] processing command: '8' id: '06368388785315187735484473520251'
[12-21-2020 16:37:05.690s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:05.690s] [tlv.c:565] processing command: '8' id: '77890477910452641075065065125400'
[12-21-2020 16:37:05.695s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:05.695s] [tlv.c:565] processing command: '4' id: '67768235767764859187014701420731'
[12-21-2020 16:37:05.695s] [channel.c:108] setting channel context for 0x7ffff8009d60 to 0x7ffff800b540
[12-21-2020 16:37:05.695s] [network_client.c:467] resolving 'tcp://www.cnn.com:443'
[12-21-2020 16:37:05.698s] [network_client.c:345] connecting to tcp://199.232.5.67:443
[12-21-2020 16:37:05.722s] [network_client.c:278] connected to 'tcp://www.cnn.com:443'
[12-21-2020 16:37:06.003s] [tlv.c:524] Handler for 4: 0x7ffff8003ac0
[12-21-2020 16:37:06.003s] [tlv.c:565] processing command: '4' id: '36798457783731169321382425794577'
[12-21-2020 16:37:06.003s] [channel.c:108] setting channel context for 0x7ffff800d880 to 0x7ffff800cfa0
[12-21-2020 16:37:06.003s] [network_client.c:467] resolving 'tcp://track.celtra.com:443'
[12-21-2020 16:37:06.007s] [network_client.c:345] connecting to tcp://54.159.176.96:443
[12-21-2020 16:37:06.036s] [network_client.c:278] connected to 'tcp://track.celtra.com:443'
[12-21-2020 16:37:06.282s] [stdapi/net/client.c:75] EOF or ERROR encountered, closing tcp channel 0x7ffff80062e0
[12-21-2020 16:37:06.282s] [channel.c:110] setting channel context for 0x7ffff80062e0 to NULL
[12-21-2020 16:37:06.287s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:06.288s] [tlv.c:565] processing command: '8' id: '43910872862872982662547375133878'
[12-21-2020 16:37:06.443s] [stdapi/net/client.c:75] EOF or ERROR encountered, closing tcp channel 0x7ffff800c7c0
[12-21-2020 16:37:06.443s] [channel.c:110] setting channel context for 0x7ffff800c7c0 to NULL
[12-21-2020 16:37:06.573s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:06.573s] [tlv.c:565] processing command: '8' id: '94323129860685925859770118525250'
[12-21-2020 16:37:06.830s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:06.830s] [tlv.c:565] processing command: '8' id: '45673475580141819507232987014159'
[12-21-2020 16:37:06.831s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:06.831s] [tlv.c:565] processing command: '8' id: '02147014586538474700171804998922'
[12-21-2020 16:37:06.833s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:06.833s] [tlv.c:565] processing command: '8' id: '25647672931524440246857007951857'
[12-21-2020 16:37:07.077s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:07.077s] [tlv.c:565] processing command: '8' id: '68976588829562686453926970397947'
[12-21-2020 16:37:07.080s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:07.080s] [tlv.c:565] processing command: '8' id: '09483278310758791784840992505556'
[12-21-2020 16:37:07.819s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:07.819s] [tlv.c:565] processing command: '8' id: '35871855312019004041213036875850'
[12-21-2020 16:37:07.836s] [tlv.c:524] Handler for 1: 0x7ffff8003d00
[12-21-2020 16:37:07.836s] [tlv.c:565] processing command: '1' id: '14869432014647282669405904928247'
[12-21-2020 16:37:07.836s] [stdapi/net/client.c:175] freeing tcp client channel 0x7ffff8091b00
[12-21-2020 16:37:07.836s] [channel.c:110] setting channel context for 0x7ffff8091b00 to NULL
[12-21-2020 16:37:07.845s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:07.845s] [tlv.c:565] processing command: '8' id: '67205538479343180020075361050438'
[12-21-2020 16:37:07.845s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:07.846s] [tlv.c:565] processing command: '8' id: '23621278840728177002258901746176'
[12-21-2020 16:37:08.463s] [stdapi/net/client.c:75] EOF or ERROR encountered, closing tcp channel 0x7ffff8091440
[12-21-2020 16:37:08.463s] [channel.c:110] setting channel context for 0x7ffff8091440 to NULL
[12-21-2020 16:37:08.608s] [tlv.c:524] Handler for 8: 0x7ffff8003ca0
[12-21-2020 16:37:08.608s] [tlv.c:565] processing command: '8' id: '79622010271096144653545187389184'

Thread 1 "mettle" received signal SIGSEGV, Segmentation fault.
0x00007ffff7d32db4 in tcp_client_write ()
(gdb) info registers
rax            0x0                 0
rbx            0x7ffff8009de0      140737354178016
rcx            0x4                 4
rdx            0xcaa               3242
rsi            0x7ffff8096271      140737354752625
rdi            0x7ffff80062e0      140737354162912
rbp            0x7ffff80062e0      0x7ffff80062e0
rsp            0x7ffffffed300      0x7ffffffed300
r8             0x0                 0
r9             0x20                32
r10            0x8080808080808080  -9187201950435737472
r11            0x206               518
r12            0x7ffff8004620      140737354155552
r13            0x8                 8
r14            0xfffffffffffffff0  -16
r15            0x9d13c292          2635317906
rip            0x7ffff7d32db4      0x7ffff7d32db4 <tcp_client_write+22>
eflags         0x10206             [ PF IF RF ]
cs             0x33                51
ss             0x2b                43
ds             0x0                 0
es             0x0                 0
fs             0x0                 0
gs             0x0                 0
(gdb) bt
#0  0x00007ffff7d32db4 in tcp_client_write ()
#1  0x00007ffff7d2c1e0 in channel_write ()
#2  0x00007ffff7d32081 in tlv_dispatcher_process_request ()
#3  0x00007ffff7d297e1 in on_c2_read ()
#4  0x00007ffff7d39b50 in on_read_tcp ()
#5  0x00007ffff7d8e825 in ev_invoke_pending ()
#6  0x00007ffff7d90909 in ev_run ()
#7  0x00007ffff7d29cb9 in mettle_start ()
#8  0x00007ffff7d28f1b in main ()
(gdb) disassemble
Dump of assembler code for function tcp_client_write:
   0x00007ffff7d32d9e <+0>:	sub    rsp,0x18
   0x00007ffff7d32da2 <+4>:	mov    QWORD PTR [rsp+0x8],rsi
   0x00007ffff7d32da7 <+9>:	mov    QWORD PTR [rsp],rdx
   0x00007ffff7d32dab <+13>:	call   0x7ffff7d2b25c <channel_get_ctx>
   0x00007ffff7d32db0 <+18>:	mov    rdx,QWORD PTR [rsp]
=> 0x00007ffff7d32db4 <+22>:	mov    rdi,QWORD PTR [rax+0x8]
   0x00007ffff7d32db8 <+26>:	mov    rsi,QWORD PTR [rsp+0x8]
   0x00007ffff7d32dbd <+31>:	add    rsp,0x18
   0x00007ffff7d32dc1 <+35>:	jmp    0x7ffff7d30e03 <network_client_write>
End of assembler dump.
(gdb) 
```
</details>

<details>
<summary> Stack Trace 2</summary>

```
[12-21-2020 15:22:33.681s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:33.681s] [tlv.c:565] processing command: '8' id: '50336157502361231216700921819035'
[12-21-2020 15:22:33.681s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:33.681s] [tlv.c:565] processing command: '8' id: '10235269059476563018315058838072'
[12-21-2020 15:22:38.886s] [mettle.c:75] Heartbeat
[12-21-2020 15:22:41.773s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:41.773s] [tlv.c:565] processing command: '8' id: '10647267531026320100611729102300'
[12-21-2020 15:22:41.773s] [tlv.c:524] Handler for 1: 0x7ffff8003d40
[12-21-2020 15:22:41.774s] [tlv.c:565] processing command: '1' id: '17328046800833920487038672373270'
[12-21-2020 15:22:44.698s] [mettle.c:75] Heartbeat
[12-21-2020 15:22:44.698s] [tlv.c:524] Handler for 4: 0x7ffff8003b00
[12-21-2020 15:22:44.698s] [tlv.c:565] processing command: '4' id: '81064402874596811881120574340915'
[12-21-2020 15:22:47.896s] [mettle.c:75] Heartbeat
[12-21-2020 15:22:47.896s] [network_client.c:467] resolving 'tcp://collector-hpn.ghostery.net:443'
[12-21-2020 15:22:47.896s] [tlv.c:524] Handler for 1026: 0x7ffff8004740
[12-21-2020 15:22:47.896s] [tlv.c:565] processing command: '1026' id: '82989871378737757381728882058572'
[12-21-2020 15:22:47.896s] [stdapi/net/client.c:194] shutting down connection for writes
[12-21-2020 15:22:47.896s] [tlv.c:524] Handler for 1: 0x7ffff8003d40
[12-21-2020 15:22:47.896s] [tlv.c:565] processing command: '1' id: '25330857180795347742716410050819'
[12-21-2020 15:22:47.896s] [tlv.c:524] Handler for 1: 0x7ffff8003d40
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '1' id: '74169535256854489508226584411543'
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 1026: 0x7ffff8004740
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '1026' id: '88329218018054061959964778955126'
[12-21-2020 15:22:47.897s] [stdapi/net/client.c:194] shutting down connection for writes
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 1026: 0x7ffff8004740
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '1026' id: '97299882912673103675573239532464'
[12-21-2020 15:22:47.897s] [stdapi/net/client.c:194] shutting down connection for writes
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 1: 0x7ffff8003d40
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '1' id: '01538617886418784501211404025742'
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 1: 0x7ffff8003d40
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '1' id: '26628820893692843121559244612701'
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '8' id: '96429244119781545910409358831628'
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '8' id: '92372678189989482692433825238836'
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 4: 0x7ffff8003b00
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '4' id: '81672173652262722854824978682014'
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 1: 0x7ffff8003d40
[12-21-2020 15:22:47.897s] [tlv.c:565] processing command: '1' id: '24692309388947124243965984359347'
[12-21-2020 15:22:47.897s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:47.898s] [tlv.c:565] processing command: '8' id: '18876334847500722273177708023824'
[12-21-2020 15:22:47.898s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:47.898s] [tlv.c:565] processing command: '8' id: '14632419718695537500444782136381'
[12-21-2020 15:22:47.898s] [tlv.c:524] Handler for 4: 0x7ffff8003b00
[12-21-2020 15:22:47.898s] [tlv.c:565] processing command: '4' id: '75787350009779936107357687400110'
[12-21-2020 15:22:47.898s] [tlv.c:524] Handler for 8: 0x7ffff8003ce0
[12-21-2020 15:22:47.898s] [tlv.c:565] processing command: '8' id: '93996051476807875145097248310308'

Thread 1 "mettle" received signal SIGSEGV, Segmentation fault.
0x00007ffff7d32d07 in tcp_client_write ()
(gdb)
(gdb)
(gdb)
(gdb) bt
#0  0x00007ffff7d32d07 in tcp_client_write ()
#1  0x00007ffff7d2c17f in channel_write ()
#2  0x00007ffff7d32020 in tlv_dispatcher_process_request ()
#3  0x00007ffff7d297e1 in on_c2_read ()
#4  0x00007ffff7d39a7d in on_read_tcp ()
#5  0x00007ffff7d8e755 in ev_invoke_pending ()
#6  0x00007ffff7d90839 in ev_run ()
#7  0x00007ffff7d29cb9 in mettle_start ()
#8  0x00007ffff7d28f1b in main ()
(gdb) r
The program being debugged has been started already.
Start it from the beginning? (y or n) n
Program not restarted.
(gdb) info re
record     registers
(gdb) info registers
rax            0x0                 0
rbx            0x7ffff80e5c80      140737355078784
rcx            0x4                 4
rdx            0x245               581
rsi            0x7ffff8006af1      140737354164977
rdi            0x7ffff80070c0      140737354166464
rbp            0x7ffff80070c0      0x7ffff80070c0
rsp            0x7ffffffed2c0      0x7ffffffed2c0
r8             0x0                 0
r9             0x20                32
r10            0x8080808080808080  -9187201950435737472
r11            0x206               518
r12            0x7ffff8004660      140737354155616
r13            0x8                 8
r14            0xfffffffffffffff0  -16
r15            0x9d13c292          2635317906
rip            0x7ffff7d32d07      0x7ffff7d32d07 <tcp_client_write+22>
eflags         0x10206             [ PF IF RF ]
cs             0x33                51
ss             0x2b                43
ds             0x0                 0
es             0x0                 0
fs             0x0                 0
gs             0x0                 0
(gdb) list
1	../../../src_toolchain/libgcc/libgcc2.c: No such file or directory.
(gdb) tui
"tui" must be followed by the name of a tui command.
List of tui subcommands:

tui disable -- Disable TUI display mode.
tui enable -- Enable TUI display mode.
tui reg -- TUI command to control the register window.

Type "help tui" followed by tui subcommand name for full documentation.
Type "apropos word" to search for commands related to "word".
Type "apropos -v word" for full documentation of commands related to "word".
Command name abbreviations are allowed if unambiguous.
(gdb) tui enable
(gdb) disassemble
Dump of assembler code for function tcp_client_write:
   0x00007ffff7d32cf1 <+0>:	sub    rsp,0x18
   0x00007ffff7d32cf5 <+4>:	mov    QWORD PTR [rsp+0x8],rsi
   0x00007ffff7d32cfa <+9>:	mov    QWORD PTR [rsp],rdx
   0x00007ffff7d32cfe <+13>:	call   0x7ffff7d2b25c <channel_get_ctx>
   0x00007ffff7d32d03 <+18>:	mov    rdx,QWORD PTR [rsp]
=> 0x00007ffff7d32d07 <+22>:	mov    rdi,QWORD PTR [rax+0x8]
   0x00007ffff7d32d0b <+26>:	mov    rsi,QWORD PTR [rsp+0x8]
   0x00007ffff7d32d10 <+31>:	add    rsp,0x18
   0x00007ffff7d32d14 <+35>:	jmp    0x7ffff7d30da2 <network_client_write>
End of assembler dump.
(gdb)
```
</details>

I added the same `NULL` check on the channel context to 5 other locations so all combinations of TCP client/server & UDP are covered for reading and writing. I only ever experienced the issue however with the TCP client write method though. Each of the channel configurations have an event callback though that is capable of setting the context to `NULL` so it seems like this is a safe bet.