### PR TITLE
Fully shutdown server channels

### DIFF
--- a/mettle/src/network_server.c
+++ b/mettle/src/network_server.c
@@ -143,13 +143,25 @@ struct network_server * network_server_new(struct ev_loop *loop)
 	return ns;
 }
 
+static int network_server_stop(struct network_server *ns)
+{
+	if (ns->listener == 0) {
+		return -1;
+	}
+	ev_io_stop(ns->loop, &ns->connect_event);
+	close(ns->listener);
+	ns->listener = 0;
+	return 0;
+}
+
 void network_server_free(struct network_server *ns)
 {
 	if (ns) {
-		if (ns->listener) {
-			close(ns->listener);
+		log_debug("closing network server channel: %p", ns);
+		network_server_stop(ns);
+		if (ns->host) {
+			free(ns->host);
 		}
-		free(ns->host);
 		free(ns);
 	}
 }

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -24,6 +24,7 @@ static void
 tcp_client_channel_free(struct tcp_client_channel *tcc)
 {
 	if (tcc) {
+		log_debug("closing tcp client channel: %p", tcc);
 		if (tcc->nc) {
 			network_client_free(tcc->nc);
 		}
@@ -214,6 +215,7 @@ static void
 udp_client_channel_free(struct udp_client_channel *ucc)
 {
 	if (ucc) {
+		log_debug("closing udp client channel: %p", ucc);
 		if (ucc->nc) {
 			network_client_free(ucc->nc);
 		}

--- a/mettle/src/stdapi/net/server.c
+++ b/mettle/src/stdapi/net/server.c
@@ -151,9 +151,14 @@ static int tcp_server_new(struct tlv_handler_ctx *ctx, struct channel *c)
 
 static int tcp_server_free(struct channel *c)
 {
-	struct network_server *nc = channel_get_ctx(c);
-	if (nc) {
+	struct network_server_channel *nsc = channel_get_ctx(c);
+	if (nsc) {
 		channel_set_ctx(c, NULL);
+		if (nsc->ns) {
+			network_server_free(nsc->ns);
+			nsc->ns = NULL;
+		}
+		free(nsc);
 	}
 	return 0;
 }

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -521,7 +521,7 @@ static struct tlv_handler * find_handler(struct tlv_dispatcher *td, uint32_t com
 {
 	struct tlv_handler *handler = NULL;
 	HASH_FIND_INT(td->handlers, &command_id, handler);
-	log_debug("Handler for %u: %p", command_id, handler);
+	log_debug("handler for %u: %p", command_id, handler);
 	return handler;
 }
 
@@ -558,11 +558,11 @@ int tlv_dispatcher_process_request(struct tlv_dispatcher *td, struct tlv_packet 
 	struct tlv_packet *response = NULL;
 	struct tlv_handler *handler = find_handler(td, ctx->command_id);
 	if (handler == NULL) {
-		log_error("no handler found for command id: '%u'", ctx->command_id);
+		log_error("no handler found for command id: %u", ctx->command_id);
 		response = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 
 	} else {
-		log_info("processing command: '%u' id: '%s'", ctx->command_id, ctx->id);
+		log_info("processing command: %u id: '%s'", ctx->command_id, ctx->id);
 		ctx->arg = handler->arg;
 		response = handler->cb(ctx);
 	}


### PR DESCRIPTION
This fixes a bug I found while working on another PR where mettle does not fully shutdown the server channel. The result is when Metasploit opens a listening socket with the TCP server channel, mettle binds to the port and then when Metasploit closes the channel, mettle remains bound to the port. This becomes problematic when Metasploit (or any other service for that matter) wants to bind to the port again.

Testing:
- [ ] Open a Mettle Meterpreter session into Metasploit
- [ ] Set a default route to push all IPv4 traffic through the new session using (`route add 0.0.0.0 0.0.0.0 -1`)
    * This will cause the server created to be bound to the remote interface via mettle
- [ ] Use any of the server modules with `SRVHOST` set to the default value of `0.0.0.0` and run it
- [ ] Stop the server job, validate that the port is not bound using netstat on the host that is running mettle
- [ ] Start the server again, see it succeed
    * Without this patch, the service would fail the second time because it can't bind to the port again since it's still in use