### PR TITLE
Fix a bug in NULL pointer bug when reading UDP channels

### DIFF
--- a/mettle/src/channel.c
+++ b/mettle/src/channel.c
@@ -255,6 +255,7 @@ static struct tlv_packet *channel_open(struct tlv_handler_ctx *ctx)
 
 	struct channel_callbacks *cbs = channel_get_callbacks(c);
 
+	log_info("creating new channel of type %s", channel_type);
 	/*
 	 * If there is an async new callback, only handle direct failures, success
 	 * handling is the responsibility of the callback.
@@ -324,10 +325,10 @@ void channel_set_interactive(struct channel *c, bool enable)
 	if (enable) {
 		struct channel_callbacks *cbs = channel_get_callbacks(c);
 		char buf[65535];
-		size_t buf_len = 0;
+		ssize_t buf_len = 0;
 		do {
 			buf_len = cbs->read_cb(c, buf, sizeof(buf));
-			if (buf_len) {
+			if (buf_len > 0) {
 				send_write_request(c, buf, buf_len);
 			}
 		} while (buf_len > 0);

--- a/mettle/src/stdapi/net/client.c
+++ b/mettle/src/stdapi/net/client.c
@@ -349,6 +349,10 @@ udp_client_read(struct channel *c, void *buf, size_t len)
 		return -1;
 	}
 	void *msg_buf = network_client_read_msg(ucc->nc, &msg_len);
+	if (msg_buf == NULL) {
+		errno = EIO;
+		return -1;
+	}
 	memcpy(buf, msg_buf, TYPESAFE_MIN(len, msg_len));
 	return msg_len;
 }


### PR DESCRIPTION
This fixes a segmentation fault where if in `udp_client_read`, `network_client_read_msg` returns `NULL` it was not being checked before being passed to `memcpy`. This lead to the Meterpreter session crashing.
After fixing this issue, I noticed that `channel_set_interactive` was incorrectly using an unsigned value for `buf_len` causing it to not properly handle error statuses of `-1`. I updated that so it will only forward data to `send_write_request` when the value is a positive integer.

You can reproduce this using the `enum_dns` module.

## Testing Steps

- [ ] Open a mettle meterpreter session
- [ ] Route all of your traffic through it using `route add 0.0.0.0 -1`
- [ ] Use the `auxiliary/gather/enum_dns` module, set the DOMAIN to `digi.ninja` (domain taken from rapid7/metasploit-framework#13952)
- [ ] Run the module a few times
    * At this point it should crash without this patch, and not crash with this patch

## Example Output

```
msf6 payload(linux/x64/meterpreter/reverse_tcp) > use auxiliary/gather/enum_dns 
msf6 auxiliary(gather/enum_dns) > show options 

Module options (auxiliary/gather/enum_dns):

   Name         Current Setting                                                                Required  Description
   ----         ---------------                                                                --------  -----------
   DOMAIN                                                                                      yes       The target domain
   ENUM_A       true                                                                           yes       Enumerate DNS A record
   ENUM_AXFR    true                                                                           yes       Initiate a zone transfer against each NS record
   ENUM_BRT     false                                                                          yes       Brute force subdomains and hostnames via the supplied wordlist
   ENUM_CNAME   true                                                                           yes       Enumerate DNS CNAME record
   ENUM_MX      true                                                                           yes       Enumerate DNS MX record
   ENUM_NS      true                                                                           yes       Enumerate DNS NS record
   ENUM_RVL     false                                                                          yes       Reverse lookup a range of IP addresses
   ENUM_SOA     true                                                                           yes       Enumerate DNS SOA record
   ENUM_SRV     true                                                                           yes       Enumerate the most common SRV records
   ENUM_TLD     false                                                                          yes       Perform a TLD expansion by replacing the TLD with the IANA TLD list
   ENUM_TXT     true                                                                           yes       Enumerate DNS TXT record
   IPRANGE                                                                                     no        The target address range or CIDR identifier
   NS                                                                                          no        Specify the nameservers to use for queries, space separated
   Proxies                                                                                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RPORT        53                                                                             yes       The target port (TCP)
   SEARCHLIST                                                                                  no        DNS domain search list, comma separated
   STOP_WLDCRD  false                                                                          yes       Stops bruteforce enumeration if wildcard resolution is detected
   THREADS      1                                                                              no        Threads for ENUM_BRT
   WORDLIST     /home/smcintyre/Repositories/metasploit-framework/data/wordlists/namelist.txt  no        Wordlist of subdomains

msf6 auxiliary(gather/enum_dns) > set DOMAIN digi.ninja
DOMAIN => digi.ninja
msf6 auxiliary(gather/enum_dns) > run

[!] dns wildcard is enable OR fake dns server
[*] Querying DNS NS records for digi.ninja
[+] digi.ninja NS: dns2.zoneedit.com
[+] digi.ninja NS: dns1.zoneedit.com
[*] Attempting DNS AXFR for digi.ninja from 45.79.110.158
[*] Query digi.ninja DNS AXFR - no results were received
[*] Attempting DNS AXFR for digi.ninja from 45.77.82.193
[*] Query digi.ninja DNS AXFR - no results were received
[*] 192.168.159.128 - Meterpreter session 1 closed.  Reason: Died
^C[-] Stopping running against current target...
[*] Control-C again to force quit all targets.
[*] Auxiliary module execution completed

```
Up to this point used the unpatched version. Between these two lines, I compiled my changes from this PR and re-ran the mettle binary.

```
msf6 auxiliary(gather/enum_dns) > 
[*] Sending stage (3008420 bytes) to 192.168.159.128
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.128:54306) at 2021-01-28 16:03:17 -0500

msf6 auxiliary(gather/enum_dns) > 
msf6 auxiliary(gather/enum_dns) > route add 0.0.0.0 -1
[*] Route added
msf6 auxiliary(gather/enum_dns) > run

[!] dns wildcard is enable OR fake dns server
[*] Querying DNS NS records for digi.ninja
[+] digi.ninja NS: dns1.zoneedit.com
[+] digi.ninja NS: dns2.zoneedit.com
[*] Attempting DNS AXFR for digi.ninja from 45.77.82.193
[*] Query digi.ninja DNS AXFR - no results were received
[*] Attempting DNS AXFR for digi.ninja from 45.79.110.158
[*] Query digi.ninja DNS AXFR - no results were received
[*] Querying DNS CNAME records for digi.ninja
[*] Querying DNS NS records for digi.ninja
[+] digi.ninja NS: dns2.zoneedit.com
[+] digi.ninja NS: dns1.zoneedit.com
[*] Querying DNS MX records for digi.ninja
[+] digi.ninja MX: alt2.aspmx.l.google.com
[+] digi.ninja MX: alt1.aspmx.l.google.com
[+] digi.ninja MX: alt4.aspmx.l.google.com
[+] digi.ninja MX: alt3.aspmx.l.google.com
[+] digi.ninja MX: aspmx.l.google.com
[*] Querying DNS SOA records for digi.ninja
[+] digi.ninja SOA: dns0.zoneedit.com
[*] Querying DNS TXT records for digi.ninja
[+] digi.ninja TXT: v=spf1 include:_spf.google.com ~all
[+] digi.ninja TXT: keybase-site-verification=RlBQzB0npOVxkoAwBYJJuWxT8xMVqLPQ1NuBwA30Dq4
[*] Querying DNS SRV records for digi.ninja
[*] Auxiliary module execution completed
msf6 auxiliary(gather/enum_dns) > 
```