### PR TITLE
Add fs_search to mettle

### DIFF
--- a/mettle/src/stdapi/fs/file.c
+++ b/mettle/src/stdapi/fs/file.c
@@ -418,7 +418,6 @@ out:
 struct tlv_packet *fs_search(struct tlv_handler_ctx *ctx)
 {
 	char *path = tlv_packet_get_str(ctx->req, TLV_TYPE_SEARCH_GLOB);
-	bool recurse;
 
 	if(path == NULL)
 	{


### PR DESCRIPTION
This adds `stdapi_fs_search` for mettle:

```
meterpreter > search -f *.c
Found 6 results...
    ./.blah.c
    ./scandir_test.c (2347 bytes)
    ./testing/blah.c
    ./testing/another_folder/blah.c
    ./testing/another_folder/hello.c
    ./testing/another_folder/stuff.c
meterpreter > search -f africa-toto.wav -d /home/space/Desktop -r false
Found 1 result...
    /home/space/Desktop/africa-toto.wav (13140922 bytes)
meterpreter > search -f passwd -d /etc
Found 3 results...
    /etc/passwd (2410 bytes)
    /etc/pam.d/passwd (92 bytes)
    /etc/cron.daily/passwd (249 bytes)
```

*Note*: Most of the testing has been done with the `i486-linux-musl` and `x86_64-linux-musl` targets so far. Currently working on testing others.