### PR TITLE
Support enumerating platforms for a extension

### DIFF
--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -180,8 +180,7 @@ module MetasploitPayloads
       # The stdapi extension is baked in
       extensions << 'stdapi'
       # Only return extensions!
-      extensions -= [ '.', '..', 'mettle', 'mettle' ]
-      extensions
+      extensions - [ '.', '..', 'mettle' ]
     end
 
     #

--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -81,12 +81,12 @@ module MetasploitPayloads
       end
     end
 
-    def self.readable_path(gem_path, msf_path)
+    def self.readable_path(gem_path, msf_path=nil)
       # Try the MSF path first to see if the file exists, allowing the MSF data
       # folder to override what is in the gem. This is very helpful for
       # testing/development without having to move the binaries to the gem folder
       # each time. We only do this is MSF is installed.
-      if ::File.readable? msf_path
+      if !msf_path.nil? && ::File.readable?(msf_path)
         warn_local_path(msf_path) if ::File.readable? gem_path
         msf_path
       elsif ::File.readable? gem_path
@@ -125,7 +125,7 @@ module MetasploitPayloads
     #
     def self.path(*path_parts)
       gem_path = expand(data_directory, ::File.join(path_parts))
-      msf_path = 'thisisnotthefileyouarelookingfor'
+      msf_path = nil
       if metasploit_installed?
         msf_path = expand(Msf::Config.data_directory, ::File.join('mettle', path_parts))
       end
@@ -178,6 +178,15 @@ module MetasploitPayloads
       extensions = ::Dir.entries(dir_path)
       # Only return extensions!
       extensions - [ '.', '..', 'mettle', 'mettle.bin' ]
+    end
+
+    #
+    # List platforms on which the specified extension is available for loading
+    #
+    def self.available_platforms(extension)
+      ::Dir.entries(path).select do |platform|
+        !(platform_path = path(platform, 'bin')).nil? && ::File.readable?(platform_path) && available_extensions(platform).include?(extension)
+      end
     end
 
     #

--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -176,8 +176,12 @@ module MetasploitPayloads
       end
 
       extensions = ::Dir.entries(dir_path)
+      extensions.select! { |extension| !extension.end_with?('.bin') }
+      # The stdapi extension is baked in
+      extensions << 'stdapi'
       # Only return extensions!
-      extensions - [ '.', '..', 'mettle', 'mettle.bin' ]
+      extensions -= [ '.', '..', 'mettle', 'mettle' ]
+      extensions
     end
 
     #


### PR DESCRIPTION
This allows enumerating the platforms (build tuples) that a particular extension has built binaries for. This is foundational work for Metasploit to be able to identify which Meterpreters a particular extension is available for.

## Testing Steps

- [x] Install the gem locally.
- [x] Start msfconsole and then load IRB.
- [x] Run `MetasploitPayloads::Mettle.available_platforms('sniffer')`
    * The `sniffer` and `stdapi` extensions are the only ones that Mettle provides. The `stdapi` is a special case though that's baked into Mettle. It's technically present even if it's not backed by files on disk.
- [x] See a list of platforms where the `sniffer` extension is available.

## Example

```
>> MetasploitPayloads::Mettle.available_platforms('sniffer')
=> 
["mips64-linux-muslsf",
 "mipsel-linux-muslsf",
 "powerpc64le-linux-musl",
 "mips-linux-muslsf",
 "powerpc-linux-muslsf",
 "s390x-linux-musl",
 "x86_64-linux-musl",
 "i486-linux-musl",
 "armv5l-linux-musleabi",
 "aarch64-linux-musl",
 "armv5b-linux-musleabi",
 "powerpc-e500v2-linux-musl"]
>> MetasploitPayloads::Mettle.available_extensions('x86_64-linux-musl')
=> ["sniffer", "stdapi"]
>> 
```