### PR TITLE
Update Linux Process Names

### DIFF
--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -29,7 +29,7 @@ get_process_info(sigar_t *sigar, sigar_pid_t pid)
 	p = tlv_packet_add_u32(p, TLV_TYPE_PID, pid);
 	p = tlv_packet_add_u32(p, TLV_TYPE_PARENT_PID, pstate.ppid);
 
-	if (strcasestr(BUILD_TUPLE, "linux")) {
+#ifdef __linux__
 		/*
 		 * for linux hosts, attempt to check if arguments can be obtained and if
 		 * not wrap the process name in brackets like `ps` and the other
@@ -50,10 +50,10 @@ get_process_info(sigar_t *sigar, sigar_pid_t pid)
 				(pstate.name[0] == '/') ? basename(pstate.name) : pstate.name);
 		}
 		sigar_proc_args_destroy(sigar, &pargs);
-	} else {
+#else
 		p = tlv_packet_add_str(p, TLV_TYPE_PROCESS_NAME,
 			(pstate.name[0] == '/') ? basename(pstate.name) : pstate.name);
-	}
+#endif
 
 	/*
 	 * the path data comes from another sigar struct; try to get it for each

--- a/mettle/src/stdapi/sys/process.c
+++ b/mettle/src/stdapi/sys/process.c
@@ -62,7 +62,7 @@ get_process_info(sigar_t *sigar, sigar_pid_t pid)
 	sigar_proc_exe_t procexe;
 	status = sigar_proc_exe_get(sigar, pid, &procexe);
 	if (status == SIGAR_OK) {
-		p = tlv_packet_add_str(p, TLV_TYPE_PROCESS_PATH, dirname(procexe.name));
+		p = tlv_packet_add_str(p, TLV_TYPE_PROCESS_PATH, procexe.name);
 	} else {
 		p = tlv_packet_add_str(p, TLV_TYPE_PROCESS_PATH, "");
 	}


### PR DESCRIPTION
This fixes an inconsistency in behavior of the Mettle's `ps` output in comparison to the other Meterpreters that run on the Linux platform. The following two characteristics were changed.

1. (Only on Linux) The process name is wrapped in brackets when the arguments can not be accessed. This is common for processes like `kworker/*`. The other Meterpreter's all do this including PHP, Python and Java. The behavior emulates what the native `ps(1)` command does.
2. The path returned for the process was updated to remove a call to `dirname` on it which was returning the directory the binary was in or `.` in many cases. This value is pretty inconsistent across all the Meterpreters, where some return the path and all of the command line arguments that went along with it. Based on the name however and following the lead of the original Meterpreter (Windows), it looks like it should just be the full path the executing binary (when it can be determined).


## Old Output (truncated)
Notice how the "Path" column is a directory, the number of entries marked as `.` and that the worker processes are not wrapped in brackets.
```
 18373  1907   java                     x86_64  smcintyre  /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-0.fc32.x86
                                                           _64/jre/bin
 18409  1119   postmaster               x86_64  postgres   .
 18753  18095  mettle                   x86_64  smcintyre  /home/smcintyre/Repositories/mettle/build/x86_64-linux-m
                                                           usl/bin
 18758  1119   postmaster               x86_64  postgres   .
 19050  11869  zsh                      x86_64  smcintyre  /usr/bin
 19337  2      kworker/9:0-ata_sff      x86_64  root       .
 19428  4004   chrome                   x86_64  smcintyre  /opt/google/chrome
 19458  4004   chrome                   x86_64  smcintyre  /opt/google/chrome
 20146  4004   chrome                   x86_64  smcintyre  /opt/google/chrome
 20186  4004   chrome                   x86_64  smcintyre  /opt/google/chrome
 20289  2      kworker/9:1-events       x86_64  root       .
 20437  1351   systemd-userwork         x86_64  root       .
 20438  1351   systemd-userwork         x86_64  root       .
 20442  1351   systemd-userwork         x86_64  root       .
```

## New Output (truncated)

```
 18373  1907   java                                   x86_64  smcintyre  /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-0.fc32.x86_64/jre/bin/java
 18409  1119   postmaster                             x86_64  postgres
 18753  18095  mettle                                 x86_64  smcintyre  /home/smcintyre/Repositories/mettle/build/x86_64-linux-musl/bin/mettle
 18758  1119   postmaster                             x86_64  postgres
 19050  11869  zsh                                    x86_64  smcintyre  /usr/bin/zsh
 19337  2      [kworker/9:0-ata_sff]                  x86_64  root
 19428  4004   chrome                                 x86_64  smcintyre  /opt/google/chrome/chrome
 19458  4004   chrome                                 x86_64  smcintyre  /opt/google/chrome/chrome
 20146  4004   chrome                                 x86_64  smcintyre  /opt/google/chrome/chrome
 20186  4004   chrome                                 x86_64  smcintyre  /opt/google/chrome/chrome
 20289  2      [kworker/9:1-events]                   x86_64  root
 20437  1351   systemd-userwork                       x86_64  root
 20438  1351   systemd-userwork                       x86_64  root
 20442  1351   systemd-userwork                       x86_64  root
```

## Testing Steps
- [ ] Load a Meterpreter session on Linux
- [ ] Run the Meterpreter `ps` command
- [ ] See output that is more similar to the output of the native `ps(1)` command on Linux as well as the other Meterpreters