### PR TITLE
set AT_SYSINFO_EHDR so that vDSO is mapped in

### DIFF
--- a/libreflect/src/stack_setup.c
+++ b/libreflect/src/stack_setup.c
@@ -17,6 +17,10 @@
 // none. Requires 18 * size_of(size_t) bytes of memory.
 void synthetic_auxv(size_t *auxv)
 {
+	// Save this value as it might be overwritten already as original auxv
+	// is reused and we don't know what order the entries are in.
+	unsigned long at_sysinfo_ehdr_value = getauxval(AT_SYSINFO_EHDR);
+
 	auxv[0] = AT_BASE;
 	auxv[2] = AT_PHDR;
 	auxv[4] = AT_ENTRY;
@@ -26,7 +30,8 @@ void synthetic_auxv(size_t *auxv)
 	auxv[12] = AT_SECURE;
     // Required for stack cookies on glibc, hope your payload doesn't get popped
 	auxv[14] = AT_RANDOM; auxv[15] = (size_t)auxv;
-	auxv[16] = AT_NULL; auxv[17] = 0;
+	auxv[16] = AT_SYSINFO_EHDR; auxv[17] = at_sysinfo_ehdr_value;
+	auxv[18] = AT_NULL; auxv[19] = 0;
 }
 
 // Minimum modifications for a sane auxiliary vector to run interpreted dynamic


### PR DESCRIPTION
The vDSO (virtual dynamic shared object) is a shared library that is
mapped in on Linux kernels for performance reasons. Instead of doing
context-switches for f.e. gettimeofday() one can stay in userland and
the kernel will take care of updating the values in the memory mapped
region in userland.

This patch will copy the pointer to that region properly over to the new
auxiliary vector such that the resulting reflected binary has the
ability to perform vDSO calls. For example a simple "hello world" binary
written in Go will already need this else it will crash with a SIGSEGV
on x86-64 Linux systems.