### PR TITLE
set AT_SYSINFO_EHDR so that vDSO is mapped in

### DIFF
--- a/libreflect/src/stack_setup.c
+++ b/libreflect/src/stack_setup.c
@@ -1,6 +1,7 @@
 #include <elf.h>
 #include <link.h>
 #include <sys/types.h>
+#include <sys/auxv.h>
 
 #include <reflect.h>
 
@@ -17,6 +18,10 @@
 // none. Requires 18 * size_of(size_t) bytes of memory.
 void synthetic_auxv(size_t *auxv)
 {
+	// Save this value as it might be overwritten already as original auxv
+	// is reused and we don't know what order the entries are in.
+	unsigned long at_sysinfo_ehdr_value = getauxval(AT_SYSINFO_EHDR);
+
 	auxv[0] = AT_BASE;
 	auxv[2] = AT_PHDR;
 	auxv[4] = AT_ENTRY;
@@ -26,7 +31,8 @@ void synthetic_auxv(size_t *auxv)
 	auxv[12] = AT_SECURE;
     // Required for stack cookies on glibc, hope your payload doesn't get popped
 	auxv[14] = AT_RANDOM; auxv[15] = (size_t)auxv;
-	auxv[16] = AT_NULL; auxv[17] = 0;
+	auxv[16] = AT_SYSINFO_EHDR; auxv[17] = at_sysinfo_ehdr_value;
+	auxv[18] = AT_NULL; auxv[19] = 0;
 }
 
 // Minimum modifications for a sane auxiliary vector to run interpreted dynamic

--- a/libreflect/src/stack_setup.c
+++ b/libreflect/src/stack_setup.c
@@ -15,7 +15,7 @@
  **/
 
 // Builds the foundation of a minimally-viable auxiliary vector when we have
-// none. Requires 18 * size_of(size_t) bytes of memory.
+// none. Requires 20 * size_of(size_t) bytes of memory.
 void synthetic_auxv(size_t *auxv)
 {
 	// Save this value as it might be overwritten already as original auxv


### PR DESCRIPTION
The vDSO (virtual dynamic shared object) is a shared library that is
mapped in on Linux kernels for performance reasons. Instead of doing
context-switches for f.e. gettimeofday() one can stay in userland and
the kernel will take care of updating the values in the memory mapped
region in userland.

This patch will copy the pointer to that region properly over to the new
auxiliary vector such that the resulting reflected binary has the
ability to perform vDSO calls. For example a simple "hello world" binary
written in Go will already need this else it will crash with a SIGSEGV
on x86-64 Linux systems.

To test we create a simple hello world in Golang.

```
$ cat > test.go << EOF
package main
import "fmt"
func main() {
fmt.Println("hello world")
}
EOF
$ go build test.go && ./test
hello world
```

Before adding the patch we get the following:

```
$ ulimit -c unlimited
$ ./build/linux.x86_64/libreflect/examples/noexec ./test
Segmentation fault (core dumped)
$ gdb ./build/linux.x86_64/bin/noexec core
...
(gdb) x/i $rip
=> 0xffffffffff600000: Cannot access memory at address
(gdb)
```

After adding the patch we get this:

```
$ ./build/linux.x86_64/libreflect/examples/noexec ./test
hello world
```