### PR TITLE
Only return the username for getuid

### DIFF
--- a/mettle/src/stdapi/sys/config.c
+++ b/mettle/src/stdapi/sys/config.c
@@ -62,6 +62,11 @@ struct tlv_packet *sys_config_getenv(struct tlv_handler_ctx *ctx)
 struct tlv_packet *sys_config_getuid(struct tlv_handler_ctx *ctx)
 {
 	struct tlv_packet *p = NULL;
+
+#ifdef _WIN32
+	/* not supported on Windows */
+	p = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
+#else
 	struct passwd *pw = getpwuid(geteuid());
 
 	if (pw)
@@ -71,6 +76,7 @@ struct tlv_packet *sys_config_getuid(struct tlv_handler_ctx *ctx)
 	} else {
 		p = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}
+#endif
 	return p;
 }
 
@@ -96,9 +102,13 @@ struct tlv_packet *sys_config_sysinfo(struct tlv_handler_ctx *ctx)
 
 struct tlv_packet *sys_config_localtime(struct tlv_handler_ctx *ctx)
 {
-	struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+	struct tlv_packet *p = NULL;
 
-#ifndef _WIN32
+#ifdef _WIN32
+	/* not supported on Windows */
+	p = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
+#else
+	p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
 	char dateTime[128] = { 0 };
 	time_t t = time(NULL);
 	struct tm lt = { 0 };

--- a/mettle/src/stdapi/sys/config.c
+++ b/mettle/src/stdapi/sys/config.c
@@ -61,28 +61,16 @@ struct tlv_packet *sys_config_getenv(struct tlv_handler_ctx *ctx)
 
 struct tlv_packet *sys_config_getuid(struct tlv_handler_ctx *ctx)
 {
-	struct tlv_packet *p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
-
-#ifndef _WIN32
-# ifndef HOST_NAME_MAX
-#  if defined(_POSIX_HOST_NAME_MAX)
-#   define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
-#  elif defined(MAXHOSTNAMELEN)
-#   define HOST_NAME_MAX MAXHOSTNAMELEN
-#  endif
-# endif /* HOST_NAME_MAX */
-	char *username = "no-user";
+	struct tlv_packet *p = NULL;
 	struct passwd *pw = getpwuid(geteuid());
+
 	if (pw)
 	{
-		username = pw->pw_name;
+		p = tlv_packet_response_result(ctx, TLV_RESULT_SUCCESS);
+		p = tlv_packet_add_str(p, TLV_TYPE_USER_NAME, pw->pw_name);
+	} else {
+		p = tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 	}
-	char hostname[HOST_NAME_MAX] = "no-hostname";
-	gethostname(hostname, HOST_NAME_MAX);
-	p = tlv_packet_add_fmt(p, TLV_TYPE_USER_NAME,
-			"%s @ %s (uid=%d, gid=%d, euid=%d, egid=%d)",
-			username, hostname, getuid(), getgid(), geteuid(), getegid());
-#endif /* _WIN32 */
 	return p;
 }
 


### PR DESCRIPTION
This is one of two changes needed to fix rapid7/metasploit-framework#15672 which is caused by the Meterpreters returning inconsistent values for the `sys.config.getuid`. Despite being called "getuid" it should return the username. What it was doing prior to these changes was returning a string containing the username and hostname strings as well as the uid, gid, euid, and egid integer values. I also updated it so if the username can't be resolved the function fails instead of returning a fake value.

## Testing

- [ ] Establish a session into Metasploit
- [ ] Run the `getuid` command
- [ ] See the username and only the username