### PR TITLE
Fix reliability of reverse port forwarding

### DIFF
--- a/mettle/src/network_server.c
+++ b/mettle/src/network_server.c
@@ -43,9 +43,7 @@ struct network_server {
 void connect_cb(struct ev_loop *loop, struct ev_io *w, int revents)
 {
 	struct network_server *ns = w->data;
-	struct sockaddr_storage sockaddr;
-	socklen_t slen;
-	int fd = accept(ns->listener, (struct sockaddr *)&sockaddr, &slen);
+	int fd = accept(ns->listener, NULL, NULL);
 	if (fd < 0) {
 		log_error("could not accept: %s", strerror(errno));
 	} else if (fd > FD_SETSIZE) {


### PR DESCRIPTION
This fixes an intermittent failure in reverse port forwarding.

My initial observation was that some payloads (e.g. `linux/x86/meterpreter/reverse_tcp`) did not successfully catch shells from a reverse port forward, and others would fail intermittently.

To (attempt to) reproduce (noting that the root cause of this turned out to be uninitialized memory, so maybe it just works on your system 🤷‍♀️):

- [ ] Run a mettle shell (I found the most reproducibility with `linux/x86/meterpreter/reverse_tcp`), and catch it with Metasploit
- [ ] Run `route add 0 0 -1`
- [ ] Run a reverse payload handler through that (e.g. `handler -p linux/x64/meterpreter/reverse_tcp -P 4444 -H 0.0.0.0`) - it should report that the session handler is occurring "via the meterpreter on session 1".
- [ ] Run a payload that should go back through that connection (e.g. `msfvenom -p linux/x64/meterpreter/reverse_tcp -f elf lport=4444 lhost=127.0.0.1`)
- [ ] Verify that the shell is not caught (you may need to repeat this multiple times with different payloads)

The debug log was showing the following whenever a connection attempt was made, but failed:

`[network_server.c:50] could not accept: Invalid argument`

Looking at the doco for [accept](https://man7.org/linux/man-pages/man2/accept.2.html), this can occur when the third parameter (`addrlen`) is invalid (e.g., is negative). 

The mettle code does not initialize this value, thus the intermittent failure. The retrieved address value is never actually used, so I set it to NULL. Prior to this fix, failures would occur on between 20% and 100% of attempted reverse connections (depending on the payload). Following this fix, I have not observed a single "Invalid argument" in the log.