### PR TITLE
Update stdapi_fs_delete_dir to be recusive

### DIFF
--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -27,6 +27,7 @@ libmettle_la_SOURCES += c2_tcp.c
 libmettle_la_SOURCES += channel.c
 libmettle_la_SOURCES += coreapi.c
 libmettle_la_SOURCES += crypttlv.c
+libmettle_la_SOURCES += eio_rmtree.c
 libmettle_la_SOURCES += extension.c
 libmettle_la_SOURCES += extensions.c
 libmettle_la_SOURCES += http_client.c

--- a/mettle/src/eio_rmtree.c
+++ b/mettle/src/eio_rmtree.c
@@ -61,9 +61,7 @@ eio_rmtree_lstat_cb(eio_req *req)
 		return req->result;
 	}
 
-	if (S_ISLNK(buf->st_mode)) {
-		new_req = eio_unlink(path, 0, set_dents_cb, ctx);
-	} else if (S_ISDIR(buf->st_mode)) {
+	if (S_ISDIR(buf->st_mode)) {
 		new_req = eio_rmtree(path, 0, set_dents_cb, ctx);
 	} else {
 		new_req = eio_unlink(path, 0, set_dents_cb, ctx);
@@ -92,7 +90,7 @@ eio_rmtree_readdir_cb(eio_req *req)
 			return error;
 		}
 
-		name += strlen (name) + 1;
+		name += strlen(name) + 1;
 	}
 	return 0;
 }

--- a/mettle/src/eio_rmtree.c
+++ b/mettle/src/eio_rmtree.c
@@ -1,0 +1,159 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <linux/limits.h>
+
+#include "eio_rmtree.h"
+
+struct rmtree_ctx {
+	char path[PATH_MAX];
+	eio_req* grp_dents;
+	eio_req* grp_dir;
+	eio_cb cb;
+	void *cb_data;
+} rmtree_ctx;
+
+static int
+_grp_add(eio_req *grp, eio_req *req) {
+	if (!req) {
+		grp->result = -1;
+		return -1;
+	}
+
+	eio_grp_add(grp, req);
+	return 0;
+}
+
+static int
+set_dents_cb(eio_req *req)
+{
+	struct rmtree_ctx *ctx = req->data;
+
+	if (req->result < 0) {
+		ctx->grp_dents->result = req->result;
+	}
+
+	return req->result;
+}
+
+static int
+set_dir_cb(eio_req *req)
+{
+	struct rmtree_ctx *ctx = req->data;
+
+	if (req->result < 0) {
+		ctx->grp_dir->result = req->result;
+	}
+
+	return req->result;
+}
+
+static int
+eio_rmtree_lstat_cb(eio_req *req)
+{
+	struct rmtree_ctx *ctx = req->data;
+	const char *path = EIO_PATH(req);
+	struct stat *buf = EIO_STAT_BUF(req);
+	eio_req *new_req;
+
+	if (set_dents_cb(req) < 0) {
+		return req->result;
+	}
+
+	if (S_ISLNK(buf->st_mode)) {
+		new_req = eio_unlink(path, 0, set_dents_cb, ctx);
+	} else if (S_ISDIR(buf->st_mode)) {
+		new_req = eio_rmtree(path, 0, set_dents_cb, ctx);
+	} else {
+		new_req = eio_unlink(path, 0, set_dents_cb, ctx);
+	}
+	return _grp_add(ctx->grp_dents, new_req);
+}
+
+static int
+eio_rmtree_readdir_cb(eio_req *req)
+{
+	struct rmtree_ctx* ctx = req->data;
+	const char *path = ctx->path;;
+	char *name = (char *)req->ptr2;
+
+	if (set_dents_cb(req) < 0) {
+		return req->result;
+	}
+
+	for (int i = 0; i < req->result; ++i) {
+		int error;
+
+		char fq_path[PATH_MAX + 1];
+		snprintf(fq_path, sizeof(fq_path), "%s/%s", path, name);
+		error = _grp_add(ctx->grp_dents, eio_lstat(fq_path, 0, eio_rmtree_lstat_cb, ctx));
+		if (error) {
+			return error;
+		}
+
+		name += strlen (name) + 1;
+	}
+	return 0;
+}
+
+static int
+eio_rmtree_cb_dents(eio_req *req)
+{
+	struct rmtree_ctx* ctx = req->data;
+
+	if (set_dir_cb(req) < 0) {
+		return req->result;
+	}
+
+	return _grp_add(ctx->grp_dir, eio_rmdir(ctx->path, 0, set_dir_cb, ctx));
+}
+
+
+static int
+eio_rmtree_cb_dir(eio_req *req)
+{
+	struct rmtree_ctx* ctx = req->data;
+	eio_cb cb = ctx->cb;
+	req->data = ctx->cb_data;
+
+	free(ctx);
+	if (!cb) {
+		return req->result;
+	}
+	return cb(req);
+}
+
+/*
+ * Recursively delete a directory. Sub entries that are links to other directories are not followed.
+ *
+ * This uses a composite request, see the section "Creating Composite Requests". Each invocation uses two groups, one
+ * to track the deletion of the subelements, and one to track the deletion of the directory itself.
+ * http://pod.tst.eu/http://cvs.schmorp.de/libeio/eio.pod
+ */
+eio_req *
+eio_rmtree(const char *path, int pri, eio_cb cb, void *data)
+{
+	struct rmtree_ctx* ctx = malloc(sizeof(rmtree_ctx));
+	if (!ctx) {
+		return NULL;
+	}
+	strncpy(ctx->path, path, PATH_MAX);
+	ctx->cb = cb;
+	ctx->cb_data = data;
+
+	ctx->grp_dents = eio_grp(eio_rmtree_cb_dents, ctx);
+	ctx->grp_dir = eio_grp(eio_rmtree_cb_dir, ctx);
+	if (!(ctx->grp_dents && ctx->grp_dir)) {
+		free(ctx);
+		return NULL;
+	}
+	if (path == NULL) {
+		ctx->grp_dents->result = -1;
+		ctx->grp_dir->result = -1;
+	} else {
+		_grp_add(ctx->grp_dents, eio_readdir(path, EIO_READDIR_STAT_ORDER, pri, eio_rmtree_readdir_cb, ctx));
+		eio_grp_add(ctx->grp_dir, ctx->grp_dents);
+	}
+	return ctx->grp_dir;
+}

--- a/mettle/src/eio_rmtree.c
+++ b/mettle/src/eio_rmtree.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <linux/limits.h>
+#include <limits.h>
 
 #include "eio_rmtree.h"
 
@@ -54,7 +54,7 @@ eio_rmtree_lstat_cb(eio_req *req)
 {
 	struct rmtree_ctx *ctx = req->data;
 	const char *path = EIO_PATH(req);
-	struct stat *buf = EIO_STAT_BUF(req);
+	EIO_STRUCT_STAT *buf = (EIO_STRUCT_STAT *)req->ptr2;
 	eio_req *new_req;
 
 	if (set_dents_cb(req) < 0) {

--- a/mettle/src/eio_rmtree.h
+++ b/mettle/src/eio_rmtree.h
@@ -1,0 +1,9 @@
+#ifndef _EIO_RMTREE_H_
+#define _EIO_RMTREE_H_
+
+#include <eio.h>
+
+eio_req *
+eio_rmtree(const char *path, int pri, eio_cb cb, void *data);
+
+#endif

--- a/mettle/src/eio_rmtree.h
+++ b/mettle/src/eio_rmtree.h
@@ -6,10 +6,4 @@
 eio_req *
 eio_rmtree(const char *path, int pri, eio_cb cb, void *data);
 
-#ifdef _WIN32
-  #if !defined(S_ISLNK)
-    #define S_ISLNK(mode) (0)
-  #endif
-#endif
-
 #endif

--- a/mettle/src/eio_rmtree.h
+++ b/mettle/src/eio_rmtree.h
@@ -6,4 +6,10 @@
 eio_req *
 eio_rmtree(const char *path, int pri, eio_cb cb, void *data);
 
+#ifdef _WIN32
+  #if !defined(S_ISLNK)
+    #define S_ISLNK(mode) (0)
+  #endif
+#endif
+
 #endif

--- a/mettle/src/stdapi/fs/file.c
+++ b/mettle/src/stdapi/fs/file.c
@@ -34,6 +34,12 @@
 
 #define FS_SEARCH_NO_DATE UINT32_MAX
 
+#ifdef __MINGW32__
+#if !defined(S_ISLNK)
+#define	S_ISLNK(mode) (0)
+#endif
+#endif
+
 struct search_entry
 {
 	char *dir_path;

--- a/mettle/src/stdapi/fs/file.c
+++ b/mettle/src/stdapi/fs/file.c
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "tlv.h"
 #include "command_ids.h"
+#include "eio_rmtree.h"
 
 #ifdef __APPLE__
 #define st_mtim st_mtimespec
@@ -545,6 +546,32 @@ fs_mkdir(struct tlv_handler_ctx *ctx)
 	return NULL;
 }
 
+static int
+fs_rmdir_cb(eio_req *req)
+{
+	struct tlv_handler_ctx *ctx = req->data;
+	const char *path = EIO_PATH(req);
+	struct stat *buf = EIO_STAT_BUF(req);
+	eio_req *new_req = NULL;
+
+	if (req->result < 0) {
+		return fs_cb(req);
+	}
+
+	if (S_ISLNK(buf->st_mode)) {
+		new_req = eio_unlink(path, 0, fs_cb, ctx);
+	} else if (S_ISDIR(buf->st_mode)) {
+		new_req = eio_rmtree(path, 0, fs_cb, ctx);
+	}
+
+	if (!new_req) {
+		req->result = -1;
+		fs_cb(req);
+	}
+
+	return req->result;
+}
+
 struct tlv_packet *
 fs_rmdir(struct tlv_handler_ctx *ctx)
 {
@@ -553,7 +580,7 @@ fs_rmdir(struct tlv_handler_ctx *ctx)
 		return tlv_packet_response_result(ctx, TLV_RESULT_EINVAL);
 	}
 
-	eio_rmdir(path, 0, fs_cb, ctx);
+	eio_lstat(path, 0, fs_rmdir_cb, ctx);
 	return NULL;
 }
 

--- a/mettle/src/stdapi/fs/file.c
+++ b/mettle/src/stdapi/fs/file.c
@@ -551,7 +551,7 @@ fs_rmdir_cb(eio_req *req)
 {
 	struct tlv_handler_ctx *ctx = req->data;
 	const char *path = EIO_PATH(req);
-	struct stat *buf = EIO_STAT_BUF(req);
+	EIO_STRUCT_STAT *buf = (EIO_STRUCT_STAT *)req->ptr2;
 	eio_req *new_req = NULL;
 
 	if (req->result < 0) {


### PR DESCRIPTION
This is related to rapid7/metasploit-framework#13369 and updates the `stdapi_fs_delete_dir` command to recursively delete the directory. While odd, the actual logic is modeled after the existing [Python implementation](https://github.com/rapid7/metasploit-payloads/blob/c3b9bbc18889f952b65d1905cc07424141dc86f3/python/meterpreter/ext_server_stdapi.py#L1412-L1423) and aims to be as consistent with it as possible.

Notable details are:
* If the path is a symbolic link, it's deleted (non-recursively)
* If the path is a directory, all of its contents are deleted, recursively, **links are deleted not followed (non-recursive)**

## Implementation
This adds an `eio_rmtree` function that looks and behaves just like the other `eio_*` family of functions, taking an argument (a single path), priority, callback and data parameter. Under the hood, a pair of [composite requests](http://pod.tst.eu/http://cvs.schmorp.de/libeio/eio.pod#CREATING_COMPOSITE_REQUESTS) are used for each directory. The first group (`grp_dents`) tracks the progress of deleting all entries, while the second (`grp_dir`) is used to track the deletion of the directory itself. This is necessary to ensure that all entries are deleted before the directory is deleted and finally the user callback handles the result. If any operation fails, the error code within the result member is propagated up to the final handler as described in step 3 from the docs.

> In the open callback, if the open was not successful, copy req->errorno to grp->errorno and set grp->result to -1 to signal an error.

Since `eio_rmtree` is implemented in it's own file, it's pretty easy to test it in isolation without Meterpreter. To do so use these files:

<details>
<summary>rm_rf.c</summary>

```
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <poll.h>
#include <string.h>
#include <sys/stat.h>

#include "eio_rmtree.h"

int respipe [2];

void
want_poll (void)
{
	char dummy;
	//printf ("want_poll ()\n");
	write (respipe [1], &dummy, 1);
}

void
done_poll (void)
{
	char dummy;
	//printf ("done_poll ()\n");
	read (respipe [0], &dummy, 1);
}

void
event_loop (void)
{
	// an event loop. yeah.
	struct pollfd pfd;
	pfd.fd     = respipe [0];
	pfd.events = POLLIN;

	printf ("\nentering event loop\n");
	while (eio_nreqs ())
		{
			poll (&pfd, 1, -1);
			printf ("eio_poll () = %d\n", eio_poll ());
		}
	printf ("leaving event loop\n");
}

static int
all_done(eio_req *req)
{
	printf("operation completed, result: %i\n", req->result);
	return req->result;
}

static int
fs_rmdir_lstat_cb(eio_req *req)
{
	const char *path = EIO_PATH(req);
	void *ctx = path;
	struct stat *buf = EIO_STAT_BUF (req);

	if (req->result < 0) {
		return all_done(req);
	}

	printf("  fs_rmdir_lstat_cb(path=%s)\n", path);
	if (S_ISLNK(buf->st_mode)) {
		eio_unlink(path, 0, all_done, ctx);
	} else if (S_ISDIR(buf->st_mode)) {
		eio_rmtree(path, 0, all_done, NULL);
	} else {
		req->result = -1;
		return all_done(req);
	}
	return 0;
}

void* fs_rmdir(const char *path) {
	eio_lstat(path, 0, fs_rmdir_lstat_cb, NULL);
	return NULL;
}

int
main (int argc, char *argv[])
{
	if (argc < 2) {
		printf("usage: %s [path]\n", argv[0]);
		return 0;
	}

	printf ("pipe ()\n");
	if (pipe (respipe)) abort ();

	printf ("eio_init ()\n");
	if (eio_init (want_poll, done_poll)) abort ();

	fs_rmdir(argv[1]);
	event_loop ();
	return 0;
}
```
</details>

<details>
<summary>Makefile</summary>

```
TARGET = rm_rf
LIBS = -leio
CC = gcc
CFLAGS = -g -Wall

.PHONY: default all clean

default: $(TARGET)
all: default

OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
HEADERS = $(wildcard *.h)

%.o: %.c $(HEADERS)
	$(CC) $(CFLAGS) -c $< -o $@

.PRECIOUS: $(TARGET) $(OBJECTS)

$(TARGET): $(OBJECTS)
	$(CC) $(OBJECTS) -Wall $(LIBS) -o $@

clean:
	-rm -f *.o
	-rm -f $(TARGET)
```
</details>

<details>
<summary>test_rm.sh</summary>

```
#!/usr/bin/env bash

set -e
set -x

mkdir -p eio-test-dir/subdir/subsubdir
echo "Hello World" > eio-test-dir/subdir/subsubdir/textdoc
echo "wakawaka" > eio-test-dir/pacman

make rm_rf
./rm_rf eio-test-dir
```
</details>

## Testing
The easiest thing to do is use the updated `post/test/file` module from Metasploit that was added in rapid7/metasploit-framework#16021. This module will validate that directories are deleted recursively and that symbolic links are deleted but not followed.

- [ ] Build Mettle using docker
- [ ] Start Metasploit Framework and start a payload handler for `linux/x64/meterpreter_reverse_tcp` (note that this is the unstaged version)
- [ ] Run the built mettle binary from the command line.
    * For example, assuming the host architecture is 64-bit Linux and the listener is running on 192.168.159.128: `build/x86_64-linux-musl/bin/mettle -u tcp://192.168.159.128:4444`
- [ ] See the tests pass, specifically the following:
    * should delete a symbolic link target
    * should not recurse into symbolic link directories
    * should recursively delete the directory we just made