### PR TITLE
Fix file descriptor leak

### DIFF
--- a/mettle/src/process.c
+++ b/mettle/src/process.c
@@ -461,6 +461,10 @@ static struct process * process_create(struct procmgr *mgr,
 
 	log_debug("IO started on fds %d %d", p->out_fd, p->err_fd);
 
+	close(stdin_pair[0]);
+	close(stdout_pair[1]);
+	close(stderr_pair[1]);
+
 	return p;
 }
 

--- a/mettle/src/stdapi/sys/memory.c
+++ b/mettle/src/stdapi/sys/memory.c
@@ -479,6 +479,7 @@ struct addr_range *parse_maps_file(pid_t pid)
 			struct addr_range *range = malloc(sizeof(struct addr_range));
 			if(range == NULL)
 			{
+				fclose(fp);
 				return first;
 			}
 

--- a/mettle/src/stdapi/sys/memory.c
+++ b/mettle/src/stdapi/sys/memory.c
@@ -480,6 +480,8 @@ struct addr_range *parse_maps_file(pid_t pid)
 			if(range == NULL)
 			{
 				fclose(fp);
+				free(line);
+				regfree(&regex);
 				return first;
 			}
 


### PR DESCRIPTION
When a new process is created in mettle, the parent process never closes its unused file descriptors, resulting in a leak for every process created. This also fixes a file descriptor leak in the `mem_search()` code.

Following Alan's steps in the Metasploit [issue](https://github.com/rapid7/metasploit-framework/issues/16966):

### Before Fix

```
msfuser@ubuntu-18041:~$ ps aux | grep mettle
msfuser    2540  1.2  0.0   2320   776 pts/3    Sl+  17:57   0:00 ./mettle -u tcp://192.168.140.1:4444 -d 3
msfuser    2544  0.0  0.0  14432  1072 pts/2    R+   17:57   0:00 grep --color=auto mettle
msfuser@ubuntu-18041:~$ lsof -p 2540 | wc -l
10
msfuser@ubuntu-18041:~$ lsof -p 2540 | wc -l
13
```

### After Fix

```
msfuser@ubuntu-18041:~$ ps aux | grep mettle
msfuser    2111  0.3  0.0   2320  1116 pts/1    Sl+  16:52   0:00 ./mettle -u tcp://192.168.140.1:4444 -d 3
msfuser    2117  0.0  0.0  14432  1100 pts/2    S+   16:53   0:00 grep --color=auto mettle
msfuser@ubuntu-18041:~$ lsof -p 2111 | wc -l
10
msfuser@ubuntu-18041:~$ lsof -p 2111 | wc -l
10
```

### Testing

<details><summary>post/test/meterpreter</summary>

```
msf6 post(test/meterpreter) > set session 3   
session => 3                                  
msf6 post(test/meterpreter) > run             
                                              
[*] Running against session 3                 
[*] Session type is meterpreter and platform is linux
[+] should return the proper directory separator
[+] should return the current working directory
[+] should list files in the current directory
[+] should stat a directory                   
[+] should create and remove a dir            
[+] should change directories                 
[+] should create and remove files
[+] should upload a file  
[+] should move files
[+] should copy files
[+] should do md5 and sha1 of files
[+] should enumerate supported core commands
[+] should support 3 or more core commands
[+] should return its own process id
[+] should return a list of processes
[+] should return a user id
[+] should return a sysinfo Hash
[+] should return network interfaces
[+] should have an interface that matches session_host
[+] should return network routes
[*] Passed: 20; Failed: 0
[*] Post module execution completed
```

</details>

<details><summary>post/test/cmd_exec</summary>

```
msf6 post(test/meterpreter) > use post/test/cmd_exec
msf6 post(test/cmd_exec) > set session 3
session => 3
msf6 post(test/cmd_exec) > run

[*] Running against session 3
[*] Session type is meterpreter and platform is linux
[+] should return the result of echo with single quotes
[+] should return the result of echo with double quotes
[+] should return the stderr output
[+] should return the result of echo
[+] should return the full response after sleeping
[+] should return the full response after sleeping
[+] should return the result of echo 10 times
[*] Passed: 7; Failed: 0
[*] Post module execution completed
```

</details>

Fixes https://github.com/rapid7/mettle/issues/234