### PR TITLE
network_client: fix dangling pointer in resolve() function

### DIFF
--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -470,13 +470,13 @@ resolve(struct eio_req *req)
 	req->result = getaddrinfo(srv->host, srv->service, &hints, &nc->addrinfo);
 
 	if ((nc->src_addr || nc->src_port) && nc->src == NULL) {
-		char *port = NULL;
 		if (nc->src_port > 0) {
 			char port_buf[6];
 			snprintf(port_buf, sizeof(port_buf), "%u", nc->src_port);
-			port = port_buf;
+			getaddrinfo(nc->src_addr, port_buf, &hints, &nc->src);
+		} else {
+			getaddrinfo(nc->src_addr, NULL, &hints, &nc->src);
 		}
-		getaddrinfo(nc->src_addr, port, &hints, &nc->src);
 	}
 }
 


### PR DESCRIPTION
Building with `gcc-12` fails with a dangling pointer error in `resolve()`:

```
$ gcc --version
gcc (Ubuntu 12.1.0-2ubuntu1~22.04) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
$ make
Building libreflect for native
Building mettle for native
/home/user/Desktop/mettle/mettle/src/network_client.c: In function ‘resolve’:
/home/user/Desktop/mettle/mettle/src/network_client.c:479:17: error: dangling pointer ‘port’ to ‘port_buf’ may be used [-Werror=dangling-pointer=]
  479 |                 getaddrinfo(nc->src_addr, port, &hints, &nc->src);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/Desktop/mettle/mettle/src/network_client.c:475:30: note: ‘port_buf’ declared here
  475 |                         char port_buf[6];
      |                              ^~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:789: network_client.lo] Error 1
make[1]: *** [Makefile:382: install-recursive] Error 1
make: *** [make/Makefile.mettle:70: /home/user/Desktop/mettle/build/linux.x86_64/bin/mettle.built] Error 2
```

This code was introduced in 50a7891c71560f442cd64459572a840f2d2a958e.

This PR modifies the function to instead use an implicit cast from `char[]` to `char *`.
