### PR TITLE
do not build universal mach-O for libpcap

### DIFF
--- a/make/Makefile.libpcap
+++ b/make/Makefile.libpcap
@@ -5,6 +5,10 @@ ifneq (,$(findstring -linux-,$(TARGET)))
     LIBPCAP_CONFIG_FLAGS += --with-pcap=linux
 endif
 
+ifneq (,$(findstring -apple-,$(TARGET)))
+    LIBPCAP_CONFIG_FLAGS=--disable-universal
+endif
+
 ifneq (,$(findstring -iphone-,$(TARGET)))
     LIBPCAP_CONFIG_FLAGS=--with-pcap=bpf --disable-universal
     LIBPCAP_FIXUP=mkdir $(BUILD)/libpcap/net; cp ./mettle/include/compat/net/* $(BUILD)/libpcap/net/


### PR DESCRIPTION
We do not support i386 or universal binaries for artifacts, this change reduces the complexity for cross compiles to ensure `libpcap` is built only for the tuple requested.