### PR TITLE
support binding to specific host in IPv4/IPv6 format

### DIFF
--- a/mettle/src/utils.c
+++ b/mettle/src/utils.c
@@ -47,6 +47,18 @@ parse_sockaddr(struct sockaddr_storage *addr, uint16_t *port)
 		struct sockaddr_in6 *s = (struct sockaddr_in6 *)addr;
 		*port = ntohs(s->sin6_port);
 		inet_ntop(AF_INET6, &s->sin6_addr, host, INET6_ADDRSTRLEN);
+
+		if (IN6_IS_ADDR_V4MAPPED(&s->sin6_addr)) {
+			struct sockaddr_in addr4;
+
+			memset(&addr4, 0, sizeof(addr4));
+			memcpy(&addr4.sin_addr.s_addr, s->sin6_addr.s6_addr + 12, sizeof(addr4.sin_addr.s_addr));
+
+			addr4.sin_family = AF_INET;
+			addr4.sin_port   = s->sin6_port;
+
+			inet_ntop(AF_INET, &addr4.sin_addr, host, INET6_ADDRSTRLEN);
+		}
 	}
 
 	return strdup(host);


### PR DESCRIPTION
This PR makes done this [TODO](https://github.com/rapid7/mettle/blob/8de1b9a30cecb9bd628419eeceb0288266f7efed/mettle/src/network_server.c#L91) on line 90. The changes contains:

- allow to binding to specified host, instead of in6addr_any
- the change, supports both IPv4/IPv6 addresses

Many thanks to @zeroSteiner

== This PR is #243 in new branch ==