### PR TITLE
Remove deprecated file exists api call

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,10 +28,10 @@ namespace :mettle do
     each_arch do |tuple|
       file = "build/#{tuple}/bin/mettle"
 
-      if File.exists? "#{file}.exe"
+      if File.exist? "#{file}.exe"
         next
       end
-      unless File.exists? file
+      unless File.exist? file
         insane tuple, 'mettle executable does not exist'
         success = false
         next
@@ -40,7 +40,7 @@ namespace :mettle do
         insane tuple, 'mettle executable looks too big'
         success = false
       end
-      unless File.exists? "#{file}.bin"
+      unless File.exist? "#{file}.bin"
         insane tuple, 'mettle.bin (memory image) does not exist'
         success = false
       end


### PR DESCRIPTION
File.exists? was deprecated in Ruby 2.1.0 and has been removed in the Ruby 3.2.0.

- https://bugs.ruby-lang.org/issues/17391
- https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/
This PR replaces File.exists?

Continuation of https://github.com/rapid7/metasploit-framework/pull/17729