### PR TITLE
Fix memory leak bug in HTTP transport

### DIFF
--- a/mettle/src/http_client.c
+++ b/mettle/src/http_client.c
@@ -244,6 +244,16 @@ int http_request(const char *url, enum http_request req,
 	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_TIME, 60L);
 	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_LIMIT, 1L);
 
+	/*
+	 * Wait for at most 30 seconds to establish a connection,
+	 * and 60 seconds for the transfer to complete.
+	 * 
+	 * Just to prevent a hung connection from blocking the entire
+	 * http transport when sending the first HTTP request.
+	 */
+	curl_easy_setopt(conn->easy_handle, CURLOPT_CONNECTTIMEOUT, 30L);
+	curl_easy_setopt(conn->easy_handle, CURLOPT_TIMEOUT, 60L);
+
 	switch (req) {
 		case http_request_get:
 			break;


### PR DESCRIPTION
# Fix memory leak bug in HTTP transport
A memory leak issue was found and mentioned at https://github.com/rapid7/metasploit-framework/issues/18342 

## Steps to reproduce

1. Generate linux/meterpreter_reverse_https payload of ELF file with msfvenom, and set `LHOST` to an unreachable address.
e.g. `msfvenom -p linux/x64/meterpreter_reverse_https LHOST=9.8.7.6 LPORT=8443 -f elf -o rev`
2. Execute the generated executable.
3. You will notice that the memory consumption keeps increasing rapidly.

## Reason of this bug
### The event pool of `libeio` is stuck
In general, all the requests would go through `http_request()` => `eio_custom(...)` => `eio_submit(...)`, and wait for the task to be dispatched. (Memory is allocated in http_request)

When the request gets dispatched, the function pointer passed to `eio_custom` will be called i.e. `request`, and then `request(...)` will call `request_done(...)` => `http_conn_free(...)` to free the allocated memory no matter whether the HTTP request succeeded or not.

However, it seems that most requests haven't got dispatched (request is not executed). Of course, `request_done` and `http_conn_free` are not called to free the allocated memory either.

Most requests (I mean eio_req) are stuck in the eio_pool in ready state (requests have been submitted but have not yet entered the execution phase)

### Why?
If the destination is unreachable, it will cost `libcurl` 20~30 seconds to return from `curl_easy_perform`. So each request will cost about 20s to finish. When a response is successfully received, the callback function will modify `poll_timer.repeat`.

It seemed reasonable at first. However, if the destination is unreachable, `poll_timer.repeat` remained the initial value i.e. `0.01` in the first 20 seconds, and `http_poll_timer_cb` was called 20*100 times creating 2000 requests.
https://github.com/rapid7/mettle/blob/a2f3c756ea84f07b80d64ff815cfec2b2e6d27e3/mettle/src/c2_http.c#L239

When the first request finishes, if the destination is unreachable, it will set the transport status to 
`c2_transport_state_unreachable`, causing the main transport monitor `transport_cb` to restart the HTTP transport.

I also found that `http_transport_stop` did not properly stop the poll loop. But it didn't make situation worse, as the `transport_cb` will restart the HTTP transport immediately.

 Conclusion: HTTP transport will always create 100 new request per second, however the work can only finish `1 * eio_nthreads()` requests every 20 seconds. (`eio_nthreads()` defaults to 4)
It is not surprising that most requests stuck in the pool in such a situation.

## How I fixed it
I did three things in these commits:
1. Modify the way to stop http_transport
2. Move the ev_timer_again logic to http_poll_cb
3. Add cURL timeout when sending a request

### Modify the way to stop http_transport
The polling loop was not actually stopped previously.
This commit aims to actually stop the polling loop by explicitly calling `ev_timer_stop` and setting `poll_timer.repeat` to zero.

I think my modification will not cause race condition here, as the loop will finally stop even if `ev_timer_again` was called after `ev_timer_stop` because of `poll_timer.repeat` was set to zero.

### Move the ev_timer_again logic to http_poll_cb
Previously, the `poll_timer.repeat` value was updated in `http_poll_cb` when the request is finished, but `ev_timer_again` was called in `http_poll_timer_cb` when the timer rang.
I moved all these logic into `http_poll_cb`, so that it can update the interval based on the response status code.

### Add cURL timeout when sending a request
After the previous two commits, mettle will not send another request if the first request did not get a response. (The `poll_timer.repeat` was set to 0 after `http_transport_start`, it will remain 0 if no response has been received. Once a response was got, it will be 0.1~10 until restarted by the main transport monitor `transport_cb`)

So, I added the timeout to wait for at most 30 seconds to establish a connection, and 60 seconds for the transfer to complete.
Just to prevent a hung connection from blocking the entire http transport when sending the first HTTP request.

I think 30s and 60s are enough in most cases. Maybe it would be better to allow user to set these two timeouts in the payload options?

## Self test
I've confirmed that after applying these changes, mettle can work properly and will not consume huge amount of memory.
![image](https://github.com/rapid7/mettle/assets/37937841/570a9564-5cf8-4c81-921d-1e9a0bc4e150)

# Another thing that need to change
When testing my modified version of mettle, I found a problem unrelated to the memory leak.
https://github.com/rapid7/mettle/blob/a2f3c756ea84f07b80d64ff815cfec2b2e6d27e3/mettle/src/c2.c#L260-L271
The main transport monitor `transport_cb` is restarting the HTTP/TCP transports really fast when the`transport_state ` is `c2_transport_state_unreachable`, causing HTTP/TCP transports to restart and retry at a speed of about once per second.

Maybe the logic of `transport_cb` should be modified to wait for some seconds before restarting a transport?
