### PR TITLE
Add some logging for why TLV negotiation may fail

### DIFF
--- a/mettle/src/coreapi.c
+++ b/mettle/src/coreapi.c
@@ -122,6 +122,7 @@ static struct tlv_packet *core_negotiate_tlv_encryption(struct tlv_handler_ctx *
 		}
 	}
 #endif
+	log_error("Failed to negotiate TLV encryption");
 	return tlv_packet_response_result(ctx, TLV_RESULT_FAILURE);
 }
 

--- a/mettle/src/crypttlv.c
+++ b/mettle/src/crypttlv.c
@@ -53,7 +53,7 @@ struct tlv_encryption_ctx* create_tlv_encryption_context(unsigned int enc_flag)
 			mbedtls_ctr_drbg_init(&ctr_drbg);
 			if (!(mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, NULL, 0))) {
 				unsigned char *aes_key = calloc(sizeof(unsigned char) * AES_KEY_LEN, 1);
-				if (!(mbedtls_ctr_drbg_random(&ctr_drbg, aes_key, AES_KEY_LEN))) {
+				if (aes_key && (!(mbedtls_ctr_drbg_random(&ctr_drbg, aes_key, AES_KEY_LEN)))) {
 					ctx->key = aes_key;
 					ctx->iv = NULL;
 					ctx->initialized = false;
@@ -62,6 +62,10 @@ struct tlv_encryption_ctx* create_tlv_encryption_context(unsigned int enc_flag)
 					break;
 				} else {
 					log_error("Failed to generate a random AES key");
+					if (aes_key) {
+						free(aes_key);
+						aes_key = NULL;
+					}
 				}
 			} else {
 				// this is known to occur in cases where mettle is running

--- a/mettle/src/crypttlv.c
+++ b/mettle/src/crypttlv.c
@@ -1,4 +1,5 @@
 #include "crypttlv.h"
+#include "log.h"
 
 size_t aes_decrypt(struct tlv_encryption_ctx* ctx, const unsigned char* data, size_t data_len, unsigned char* result)
 {
@@ -59,7 +60,13 @@ struct tlv_encryption_ctx* create_tlv_encryption_context(unsigned int enc_flag)
 					mbedtls_ctr_drbg_free(&ctr_drbg);
 					mbedtls_entropy_free(&entropy);
 					break;
+				} else {
+					log_error("Failed to generate a random AES key");
 				}
+			} else {
+				// this is known to occur in cases where mettle is running
+				// in a chroot environment without access to /dev/random
+				log_error("Failed to seed the random number generator");
 			}
 			mbedtls_ctr_drbg_free(&ctr_drbg);
 			mbedtls_entropy_free(&entropy);


### PR DESCRIPTION
Until #255 is resolved, these changes intend to add logging at key locations during the TLV encryption negotiation process to help troubleshoot issues more quickly.