### PR TITLE
TLV encryption negotiation with a weak key when no entropy source is available

### DIFF
--- a/deps/mbedtls-config.h
+++ b/deps/mbedtls-config.h
@@ -34,6 +34,9 @@
 #define MBEDTLS_PLATFORM_SNPRINTF_ALT
 #define MBEDTLS_HAVE_TIME
 
+// Uncomment to test the embedded Marsenne Twister PRNG algorithm 
+// #define MBEDTLS_NO_PLATFORM_ENTROPY 
+
 /* mbed TLS feature support */
 #define MBEDTLS_CIPHER_MODE_CBC
 #define MBEDTLS_PKCS1_V15

--- a/mettle/src/Makefile.am
+++ b/mettle/src/Makefile.am
@@ -27,6 +27,7 @@ libmettle_la_SOURCES += c2_tcp.c
 libmettle_la_SOURCES += channel.c
 libmettle_la_SOURCES += coreapi.c
 libmettle_la_SOURCES += crypttlv.c
+libmettle_la_SOURCES += mtwister.c
 libmettle_la_SOURCES += eio_rmtree.c
 libmettle_la_SOURCES += extension.c
 libmettle_la_SOURCES += extensions.c

--- a/mettle/src/crypttlv.c
+++ b/mettle/src/crypttlv.c
@@ -5,13 +5,16 @@
 #include <string.h>
 
 
-int add_weak_encryption(mbedtls_ctr_drbg_context *ctr_drbg, mbedtls_entropy_context *entropy) {
-	mbedtls_entropy_init(entropy);
-	mbedtls_ctr_drbg_init(ctr_drbg);
-	return mbedtls_entropy_add_source(	entropy,
+int add_weak_encryption(void  *ctr_drbg, void *entropy) {
+#ifndef __MINGW32__
+	mbedtls_entropy_init((mbedtls_entropy_context *) entropy);
+	mbedtls_ctr_drbg_init((mbedtls_ctr_drbg_context *)ctr_drbg);
+	return mbedtls_entropy_add_source((mbedtls_entropy_context *)entropy,
 								mbedtls_mtwister_entropy_poll, NULL,
 								32, // MBEDTLS_ENTROPY_MIN_PLATFORM
 								MBEDTLS_ENTROPY_SOURCE_STRONG);
+#endif
+	return -1;
 }
 
 size_t aes_decrypt(struct tlv_encryption_ctx* ctx, const unsigned char* data, size_t data_len, unsigned char* result)

--- a/mettle/src/mtwister.c
+++ b/mettle/src/mtwister.c
@@ -1,0 +1,121 @@
+/* 
+ * An implementation of the MT19937 Algorithm for the Mersenne Twister
+ * by Evan Sultanik.  Based upon the pseudocode in: M. Matsumoto and
+ * T. Nishimura, "Mersenne Twister: A 623-dimensionally
+ * equidistributed uniform pseudorandom number generator," ACM
+ * Transactions on Modeling and Computer Simulation Vol. 8, No. 1,
+ * January pp.3-30 1998.
+ *
+ * http://www.sultanik.com/Mersenne_twister
+ * 
+ * Original code: https://github.com/ESultanik/mtwister
+ * 
+ * License: Public domain. Have fun!
+ */
+
+#define UPPER_MASK 0x80000000
+#define LOWER_MASK 0x7fffffff
+#define TEMPERING_MASK_B 0x9d2c5680
+#define TEMPERING_MASK_C 0xefc60000
+
+#include <stdint.h>
+#include <stddef.h>
+#include <time.h>
+#include "mtwister.h"
+
+int mbedtls_mtwister_entropy_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+{
+  MTRand r = seedRand((uint32_t)time(NULL));
+  int len_left = len;
+  int mem_size = 0;
+  uint32_t rand_val = 0;
+
+  while (len_left != 0)
+  {
+    rand_val = genRandLong(&r);
+    if (len_left >= 4)
+    {
+      mem_size = 4;
+    }
+    else
+    {
+      mem_size = len_left;
+    }
+    for (int i = 0; i < mem_size; i++)
+    {
+      output[len - len_left + i] = ((uint8_t *)&rand_val)[i];
+    }
+    len_left -= mem_size;
+    *olen += mem_size;
+  }
+  return 0;
+}
+
+inline static void m_seedRand(MTRand *rand, uint32_t seed)
+{
+  /* set initial seeds to mt[STATE_VECTOR_LENGTH] using the generator
+   * from Line 25 of Table 1 in: Donald Knuth, "The Art of Computer
+   * Programming," Vol. 2 (2nd Ed.) pp.102.
+   */
+  rand->mt[0] = seed & 0xffffffff;
+  for (rand->index = 1; rand->index < STATE_VECTOR_LENGTH; rand->index++)
+  {
+    rand->mt[rand->index] = (6069 * rand->mt[rand->index - 1]) & 0xffffffff;
+  }
+}
+
+/**
+ * Creates a new random number generator from a given seed.
+ */
+MTRand seedRand(uint32_t seed)
+{
+  MTRand rand;
+  m_seedRand(&rand, seed);
+  return rand;
+}
+
+/**
+ * Generates a pseudo-randomly generated long.
+ */
+uint32_t genRandLong(MTRand *rand)
+{
+
+  uint32_t y;
+  static uint32_t mag[2] = {0x0, 0x9908b0df}; /* mag[x] = x * 0x9908b0df for x = 0,1 */
+  if (rand->index >= STATE_VECTOR_LENGTH || rand->index < 0)
+  {
+    /* generate STATE_VECTOR_LENGTH words at a time */
+    int32_t kk;
+    if (rand->index >= STATE_VECTOR_LENGTH + 1 || rand->index < 0)
+    {
+      m_seedRand(rand, 4357);
+    }
+    for (kk = 0; kk < STATE_VECTOR_LENGTH - STATE_VECTOR_M; kk++)
+    {
+      y = (rand->mt[kk] & UPPER_MASK) | (rand->mt[kk + 1] & LOWER_MASK);
+      rand->mt[kk] = rand->mt[kk + STATE_VECTOR_M] ^ (y >> 1) ^ mag[y & 0x1];
+    }
+    for (; kk < STATE_VECTOR_LENGTH - 1; kk++)
+    {
+      y = (rand->mt[kk] & UPPER_MASK) | (rand->mt[kk + 1] & LOWER_MASK);
+      rand->mt[kk] = rand->mt[kk + (STATE_VECTOR_M - STATE_VECTOR_LENGTH)] ^ (y >> 1) ^ mag[y & 0x1];
+    }
+    y = (rand->mt[STATE_VECTOR_LENGTH - 1] & UPPER_MASK) | (rand->mt[0] & LOWER_MASK);
+    rand->mt[STATE_VECTOR_LENGTH - 1] = rand->mt[STATE_VECTOR_M - 1] ^ (y >> 1) ^ mag[y & 0x1];
+    rand->index = 0;
+  }
+  y = rand->mt[rand->index++];
+  y ^= (y >> 11);
+  y ^= (y << 7) & TEMPERING_MASK_B;
+  y ^= (y << 15) & TEMPERING_MASK_C;
+  y ^= (y >> 18);
+  return y;
+}
+
+/**
+ * Generates a pseudo-randomly generated double in the range [0..1].
+ */
+double genRand(MTRand *rand)
+{
+  return ((double)genRandLong(rand) / (uint32_t)0xffffffff);
+}

--- a/mettle/src/mtwister.h
+++ b/mettle/src/mtwister.h
@@ -1,0 +1,20 @@
+#ifndef __MTWISTER_H
+#define __MTWISTER_H
+
+#include <stdint.h>
+
+#define STATE_VECTOR_LENGTH 624
+#define STATE_VECTOR_M      397 /* changes to STATE_VECTOR_LENGTH also require changes to this */
+
+typedef struct tagMTRand {
+  uint32_t mt[STATE_VECTOR_LENGTH];
+  int32_t index;
+} MTRand;
+
+MTRand seedRand(uint32_t seed);
+uint32_t genRandLong(MTRand* rand);
+double genRand(MTRand* rand);
+
+int mbedtls_mtwister_entropy_poll( void *data, unsigned char *output, size_t len, size_t *olen );
+
+#endif /* #ifndef __MTWISTER_H */

--- a/mettle/src/tlv.h
+++ b/mettle/src/tlv.h
@@ -123,6 +123,7 @@ struct tlv_encryption_ctx {
 
 	uint32_t flag;
 	bool initialized;
+	bool is_weak_key;
 };
 
 struct tlv_handler_ctx {


### PR DESCRIPTION
This pull-request solves the issue [#255 ](https://github.com/rapid7/mettle/issues/255) by introducing an embedded PRNG algorithm; the original code can be found [here](https://github.com/ESultanik/mtwister)

The pull-request includes:
- Marsenne Twister algorithm with a wrapper to make it compatible with mbedtls using the functionality to add custom entropy source.  [more info here](https://mbed-tls.readthedocs.io/en/latest/kb/how-to/add-entropy-sources-to-entropy-pool/#adding-own-sources).
- Fixing the allocation of the `aes_key` with `calloc`, making sure it is not NULL and freeing it if `mbedtls_ctr_drbg_random` fails.
- Inclusion of the flag `is_weak_key` byte value inside the TLV response to notify the c2 when the mtwister is used.