### PR TITLE
Fix mettle http memory leak

### DIFF
--- a/mettle/src/c2.c
+++ b/mettle/src/c2.c
@@ -258,16 +258,21 @@ transport_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 		c2->transport_state = c2_transport_state_starting;
 
 	} if (c2->transport_state == c2_transport_state_unreachable) {
-		if (t->type->cbs.stop) {
-			t->type->cbs.stop(t);
-		}
+		
+		t = c2->curr_transport;    // old transport
+		choose_next_transport(c2); // new transport
 
-		t = choose_next_transport(c2);
-
-		if (t->type->cbs.start) {
-			t->type->cbs.start(t);
+		// switch transport only if they are different
+		if(t != c2->curr_transport) {
+			if (t->type->cbs.stop) {
+				t->type->cbs.stop(t);
+			}
+			t = c2->curr_transport;
+			if (t->type->cbs.start) {
+				t->type->cbs.start(t);
+			}
+			c2->transport_state = c2_transport_state_starting;
 		}
-		c2->transport_state = c2_transport_state_starting;
 	}
 }
 

--- a/mettle/src/http_client.c
+++ b/mettle/src/http_client.c
@@ -80,6 +80,7 @@ const char *http_conn_header_value(struct http_conn *conn, const char *key)
 void http_conn_free(struct http_conn *conn)
 {
 	if (conn) {
+		log_info(" request free  %p", conn);
 		free(conn->url);
 		if (conn->response) {
 			buffer_queue_free(conn->response);
@@ -207,6 +208,7 @@ int http_request(const char *url, enum http_request req,
 	struct http_request_data *data, struct http_request_opts *opts)
 {
 	struct http_conn *conn = calloc(1, sizeof *conn);
+	log_info("request alloc %p", conn);
 	if (conn == NULL) {
 		return -1;
 	}
@@ -243,7 +245,7 @@ int http_request(const char *url, enum http_request req,
 	 */
 	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_TIME, 60L);
 	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_LIMIT, 1L);
-
+	
 	switch (req) {
 		case http_request_get:
 			break;

--- a/mettle/src/http_client.c
+++ b/mettle/src/http_client.c
@@ -245,6 +245,25 @@ int http_request(const char *url, enum http_request req,
 	 */
 	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_TIME, 60L);
 	curl_easy_setopt(conn->easy_handle, CURLOPT_LOW_SPEED_LIMIT, 1L);
+	  
+
+	/*
+
+	* Wait for at most 30 seconds to establish a connection,
+
+	* and 60 seconds for the transfer to complete.
+
+	*
+
+	* Just to prevent a hung connection from blocking the entire
+
+	* http transport when sending the first HTTP request.
+
+	*/
+
+	curl_easy_setopt(conn->easy_handle, CURLOPT_CONNECTTIMEOUT, 30L);
+
+	curl_easy_setopt(conn->easy_handle, CURLOPT_TIMEOUT, 60L);
 	
 	switch (req) {
 		case http_request_get:


### PR DESCRIPTION
This pull-request fixes the issue described here [18342](https://github.com/rapid7/metasploit-framework/issues/18342) 

### Testing

Checkout to the commit that includes only the logging of the allocations:
```
git checkout a8abf51
make TARGET=x86_64-linux-musl D=1
```

Try to connect to an offline handler:
```
./build/x86_64-linux-musl/bin/mettle -u "http://<offline handler>/X6H8zuvusVo_IzkhWUgidgD7Zeju2Td|--ua 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0'" -b 0 -d 2
```

The logs should look like this (if you see alloc&free it's because you are probably using a local address and maybe is handled by the kernel, I suggest to use private addresses like 10.0.0.1):
```
[06-19-2024 15:10:38.385s] [tlv.c:498] Registering command 10, cb 0x7f823760cb6a, arg 
...
[06-19-2024 15:10:38.386s] [tlv.c:498] Registering command 1116, cb 0x7f823761a6b6, arg 0x55555679d040
[06-19-2024 15:10:38.386s] [mettle.c:75] Heartbeat
[06-19-2024 15:10:38.396s] [http_client.c:211] request alloc 0x5555567a2c00
[06-19-2024 15:10:38.406s] [http_client.c:211] request alloc 0x5555567aecc0
[06-19-2024 15:10:38.416s] [http_client.c:211] request alloc 0x5555567bace0
[06-19-2024 15:10:38.426s] [http_client.c:211] request alloc 0x5555567c6d00
[06-19-2024 15:10:38.436s] [http_client.c:211] request alloc 0x5555567d2d20
[06-19-2024 15:10:38.447s] [http_client.c:211] request alloc 0x5555567d48a0
[06-19-2024 15:10:38.457s] [http_client.c:211] request alloc 0x5555567d6460
[06-19-2024 15:10:38.467s] [http_client.c:211] request alloc 0x5555567d8020
[06-19-2024 15:10:38.477s] [http_client.c:211] request alloc 0x5555567d9be0
[06-19-2024 15:10:38.487s] [http_client.c:211] request alloc 0x5555567db7a0
[06-19-2024 15:10:38.497s] [http_client.c:211] request alloc 0x5555567dd360
[06-19-2024 15:10:38.508s] [http_client.c:211] request alloc 0x5555567def20
[06-19-2024 15:10:38.518s] [http_client.c:211] request alloc 0x5555567e0ae0
[06-19-2024 15:10:38.528s] [http_client.c:211] request alloc 0x5555567e26a0
[06-19-2024 15:10:38.538s] [http_client.c:211] request alloc 0x5555567e4260
[06-19-2024 15:10:38.548s] [http_client.c:211] request alloc 0x5555567e5e20
[06-19-2024 15:10:38.558s] [http_client.c:211] request alloc 0x5555567e79e0
[06-19-2024 15:10:38.569s] [http_client.c:211] request alloc 0x5555567e95a0
[06-19-2024 15:10:38.579s] [http_client.c:211] request alloc 0x5555567eb160
[06-19-2024 15:10:38.589s] [http_client.c:211] request alloc 0x5555567ecd20
[06-19-2024 15:10:38.599s] [http_client.c:211] request alloc 0x5555567ee8e0
[06-19-2024 15:10:38.609s] [http_client.c:211] request alloc 0x5555567f04a0
[06-19-2024 15:10:38.619s] [http_client.c:211] request alloc 0x5555567f2060
[06-19-2024 15:10:38.630s] [http_client.c:211] request alloc 0x5555567f3c20
[06-19-2024 15:10:38.640s] [http_client.c:211] request alloc 0x5555567f57e0
[06-19-2024 15:10:38.650s] [http_client.c:211] request alloc 0x5555567f73a0
[06-19-2024 15:10:38.660s] [http_client.c:211] request alloc 0x5555567f8f60
[06-19-2024 15:10:38.670s] [http_client.c:211] request alloc 0x5555567fab20
[06-19-2024 15:10:38.680s] [http_client.c:211] request alloc 0x5555567fc6e0
[06-19-2024 15:10:38.691s] [http_client.c:211] request alloc 0x5555567fe2a0
[06-19-2024 15:10:38.701s] [http_client.c:211] request alloc 0x5555567ffe60
[06-19-2024 15:10:38.711s] [http_client.c:211] request alloc 0x555556801a20
[06-19-2024 15:10:38.721s] [http_client.c:211] request alloc 0x5555568035e0
[06-19-2024 15:10:38.731s] [http_client.c:211] request alloc 0x5555568051a0
[06-19-2024 15:10:38.741s] [http_client.c:211] request alloc 0x555556806d60
[06-19-2024 15:10:38.752s] [http_client.c:211] request alloc 0x555556808920
[06-19-2024 15:10:38.762s] [http_client.c:211] request alloc 0x55555680a4e0
[06-19-2024 15:10:38.772s] [http_client.c:211] request alloc 0x55555680c0a0
[06-19-2024 15:10:38.782s] [http_client.c:211] request alloc 0x55555680dc60
[06-19-2024 15:10:38.792s] [http_client.c:211] request alloc 0x55555680f820
[06-19-2024 15:10:38.802s] [http_client.c:211] request alloc 0x5555568113e0
[06-19-2024 15:10:38.813s] [http_client.c:211] request alloc 0x555556812fa0
[06-19-2024 15:10:38.823s] [http_client.c:211] request alloc 0x555556814b60
[06-19-2024 15:10:38.833s] [http_client.c:211] request alloc 0x555556816720
[06-19-2024 15:10:38.843s] [http_client.c:211] request alloc 0x5555568182e0
[06-19-2024 15:10:38.853s] [http_client.c:211] request alloc 0x555556819ea0
[06-19-2024 15:10:38.863s] [http_client.c:211] request alloc 0x55555681ba60
[06-19-2024 15:10:38.874s] [http_client.c:211] request alloc 0x55555681d620
[06-19-2024 15:10:38.884s] [http_client.c:211] request alloc 0x55555681f1e0
[06-19-2024 15:10:38.894s] [http_client.c:211] request alloc 0x555556820da0
[06-19-2024 15:10:38.904s] [http_client.c:211] request alloc 0x555556822960
[06-19-2024 15:10:38.914s] [http_client.c:211] request alloc 0x555556824520
```

Now checkout to the full fix:
```
git checkout 45e89ac
make TARGET=x86_64-linux-musl D=1
```

Run mettle again
```
./build/x86_64-linux-musl/bin/mettle -u "http://<offline handler>/X6H8zuvusVo_IzkhWUgidgD7Zeju2Td|--ua 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0'" -b 0 -d 2
```

The logs should look something like this:
```
[06-20-2024 06:49:57.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:49:57.208s] [http_client.c:211] request alloc 0x555556cb6c20
[06-20-2024 06:50:02.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:07.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:12.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:17.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:22.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:27.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:27.210s] [http_client.c:83]  request free  0x555556cb6c20
[06-20-2024 06:50:32.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:37.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:37.211s] [http_client.c:211] request alloc 0x555556cb6c20
[06-20-2024 06:50:42.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:47.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:52.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:50:57.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:51:02.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:51:07.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:51:07.211s] [http_client.c:83]  request free  0x555556cb6c20
[06-20-2024 06:51:12.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:51:17.108s] [mettle.c:75] Heartbeat
[06-20-2024 06:51:17.212s] [http_client.c:211] request alloc 0x555556cb6c20
```

## Root Cause
As explained [here](https://github.com/rapid7/mettle/pull/253) the "memory leak" happen due to the following reasons:
- The `http_transport` start with a very fast async polling rate (0.01 seconds sleep) and until the first one is completed the polling timer stays with the original value.

- The `transport_cb` will restart the transport even if it's the same, meaning after we reach for the first time the `http_poll_cb` and we set the transport as `unreachable`, it will be stopped and started again, restarting the cycle of requests allocation.

- cURL doesn't have a preset timeout.

## Fix Description

### http_client
- Included the cURL timeout flags as suggested by [Jemmy1228](https://github.com/rapid7/mettle/pull/253)

### c2
- Modified the `transport_cb` to switch the transport only if is different from the current one

### c2_http
- `http_transport_start` will execute the `http_poll_timer_cb` only one time by setting the `poll_timer.repeat = 0`
- `http_poll_cb` now has a bool value `online` to keep track of the state of the c2. This is useful also to re-negotiate the session with metasploit without restarting the transport, just setting the `first_packet = 1` 
- the `ev_timer_again` call is moved from `http_poll_timer_cb` to `http_poll_cb`, the `online` flag is used to keep mettle waiting for the http request to be completed when `online == false`, this is done by setting `poll_timer.repeat = 0` after calling `ev_timer_again` with 10 seconds delay

## Other Fixes
### c2_http
- When the c2 is online, `http_poll_cb` increases slowly the sleeping time, ensuring a faster connection, this was done to have a similar behaviour of the Windows Meterpreter.