### PR TITLE
Fix load extension regression

### DIFF
--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -204,7 +204,7 @@ module MetasploitPayloads
         format = :process_image
       else
         format = :exec
-        name = [name,suffix].join('.') unless suffix&.strip&.empty?
+        name = [name,suffix].join('.') unless suffix.nil? || suffix.strip.empty?
       end
       self.read(platform, format, name)
     end

--- a/spec/metasploit_payloads/mettle/mettle_spec.rb
+++ b/spec/metasploit_payloads/mettle/mettle_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe MetasploitPayloads::Mettle do
             'modname',
             nil
           )
-        end.to raise_error MetasploitPayloads::Mettle::NotFoundError, 'build-tuple/modname. not found'
+        end.to raise_error MetasploitPayloads::Mettle::NotFoundError, 'build-tuple/modname not found'
       end
     end
 
@@ -86,6 +86,18 @@ RSpec.describe MetasploitPayloads::Mettle do
             'suffix'
           )
         end.to raise_error MetasploitPayloads::Mettle::NotFoundError, 'build-tuple/modname.suffix not found'
+      end
+    end
+
+    context 'when the suffix contains only whitespace' do
+      it 'raises an error' do
+        expect do
+          described_class.load_extension(
+            'build-tuple',
+            'modname',
+            '           '
+          )
+        end.to raise_error MetasploitPayloads::Mettle::NotFoundError, 'build-tuple/modname not found'
       end
     end
   end


### PR DESCRIPTION
Updates Mettle's `load_extension` method to handle `nil` suffix correctly - spotted as part of https://github.com/rapid7/metasploit-framework/issues/19305

As it looks like Github Actions have been accidentally disabled for this repo; here's the passing RSpec output until it's enabled again:

```
Finished in 0.01356 seconds (files took 0.08763 seconds to load)
15 examples, 0 failures
```
