### PR TITLE
Update how extensions are loaded and their commands are registered

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -49,8 +49,8 @@ A few things to know when creating your extension:
 Some Details
 ------------
 
-Communication between Mettle and extensions occurs over standard I/O (stdin, stdout, stderr).  When an extension first starts up, it sends the commands it accepts+handles (as strings delimited by newline characters) to Mettle via stdout, finally sending two newline characters back-to-back at the end to indicate that the full list of commands has been sent.  Mettle will associate these commands to the specifc extension, allowing for future incoming TLV requests to be directed to the proper handling code.
+Communication between Mettle and extensions occurs over standard I/O (stdin, stdout, stderr).  Once Mettle has started the extension subprocess, it will forward the CORE_LOADLIB command to the extension process. The extension process then replies to it with the result and command IDs that it supports. The parent Mettle process watches for the response to this CORE_LOADLIB command and will associate these commands to the specifc extension, allowing for future incoming TLV requests to be directed to the proper handling code.
 
-Once Mettle has associated an extension's commands, the stdin and stdout communications between Mettle and the extension switch over to exclusively using unencrypted TLV packets.  This allows Mettle to be the central point of all TLV en/decryption between the target and Framework endpoints, while getting the value out of reusing the known+existing TLV format and processing code.
+The stdin and stdout communications between Mettle and the extension process exclusively use unencrypted TLV packets.  This allows Mettle to be the central point of all TLV en/decryption between the target and Framework endpoints, while getting the value out of reusing the known+existing TLV format and processing code.
 
 Additionally, extensions can log error (e.g. log_error()), informational (e.g. log_info()), or debug (e.g. log_debug()) messages as plain old NULL-terminated strings to Mettle via stderr.  Currently, Mettle will treat all incoming extension messages via stderr at the "info" (2) log level.  

--- a/mettle/src/extensions.h
+++ b/mettle/src/extensions.h
@@ -5,14 +5,22 @@
 #ifndef _EXTENSIONS_H_
 #define _EXTENSIONS_H_
 
+#include <stdbool.h>
+
 struct mettle;
+
+struct extension_process {
+	struct mettle *m;
+	struct process *p;
+	bool ready;
+};
 
 struct extmgr *extmgr_new();
 
-int extension_start_executable(struct mettle *m, const char *full_path,
+struct extension_process * extension_start_executable(struct mettle *m, const char *full_path,
 	const char* args);
 
-int extension_start_binary_image(struct mettle *m, const char *name,
+struct extension_process * extension_start_binary_image(struct mettle *m, const char *name,
 	const unsigned char *bin_image, size_t bin_image_len, const char* args);
 
 void extmgr_free(struct extmgr *mgr);


### PR DESCRIPTION
This fixes #262 by updating how extensions are loaded and their commands are registered. Both before and after this change, extensions are started within a dedicated child process of Mettle. Stdapi is an exception to this rule and is treated as a special case which makes the sniffer extension the only real extension at this time. Before these changes, the child process would send the command IDs it supported as ASCII encoded numbers to the parent process over stdout. The Mettle parent process would read these until a new line was encountered, at which point it would take all the numbers it read and register them as commands to be sent to the extension. Once the commands were registered, the Mettle parent process and extension child process would switch to using the standard TLVs. There was something wrong with this logic that processed the ASCII-encoded numbers that caused the first command ID to be registered X times where X is the total number of commands sent by the extension child process. The Mettle parent process was also responding to the `CORE_LOADLIB` command with a successful result before the extension was fully initialized. This seems like a problem because if the extension's `main` method realizes it can't load, that error would be lost.

Instead of debugging the parsing code, I updated the extension and core code to *always* communicate with TLVs. After the extension child process has been started, the parent simply forwards the original CORE_LOADLIB command packet which allows the extension to reply to it itself and in doing so include all of the command IDs that it has registered. This does mean that the handler for `CORE_LOADLIB` is now treated as a special case though because all extensions should register it to accept the forwarded request which triggered it's original load. Both the extension client and Mettle parent processes have conditions to ensure that `CORE_LOADLIB` is filtered out of the commands to be registered to the extension. This ensures that the Mettle parent process's original handler can continue to be used to load subsequent extensions.

# Testing

- [ ] Open a Mettle Meterpreter session
- [ ] Load the sniffer extension (`load sniffer`)
- [ ] Run a sniffer command to see it's working (`sniffer_interfaces`)