### PR TITLE
Fixes an incorrectly named workflow variable

### DIFF
--- a/.github/workflows/metasploit-framework_acceptance.yml
+++ b/.github/workflows/metasploit-framework_acceptance.yml
@@ -35,18 +35,6 @@ on:
   pull_request:
     branches:
       - '*'
-    paths:
-      - 'build/**'
-      - 'deps/**'
-      - 'docker/**'
-      - 'lib/**'
-      - 'libreflect/**'
-      - 'make/**'
-      - 'mettle/**'
-      - 'pkg/**'
-      - 'spec/**'
-      - 'util/**'
-      - '.github/**'
 #   Example of running as a cron, to weed out flaky tests
 #  schedule:
 #    - cron: '*/15 * * * *'
@@ -55,5 +43,5 @@ jobs:
   build:
     uses: rapid7/metasploit-framework/.github/workflows/shared_meterpreter_acceptance.yml@master
     with:
-      metasploit-framework_commit: ${{ github.event.inputs.metasploitFrameworkCommit }}
+      metasploit_framework_commit: ${{ github.event.inputs.metasploitFrameworkCommit }}
       build_mettle: true


### PR DESCRIPTION
Fixes an incorrectly named workflow variable that was missed after some refactoring was done as part of the following metasploit-framework PR:
- https://github.com/rapid7/metasploit-framework/pull/19564

## Verification

- [ ] Ensure code changes sane