### PR TITLE
Updates Ruby version in `verify.yml`

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,8 +33,9 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ruby:
-          - '3.0'
-          - '3.3.0-preview1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
 


### PR DESCRIPTION
Updates the Ruby version in `.github/workflows/verify.yml` in order to fix the following error that has been failing on CI recently:

https://github.com/rapid7/mettle/actions/runs/13198273602/job/36844309528


# Testing
- [ ] CI passes