### PR TITLE
Fix compilation on MacOSX

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -41,7 +41,13 @@ ifeq "$(D)" "1"
     CFLAGS:=$(CFLAGS) -g
 endif
 
+# Libraries cannot be compiled with -Werror due to the multiple compilation warnings.
+# This would be probably a good idea to update them to their latest versions and see if these issues are fixed.
 ENV:=$(ENV) ARFLAGS="cr" AR_FLAGS="cr" LDFLAGS="-L$(BUILD)/lib $(LDFLAGS)" CC="$(CC)" CPP="$(CPP)" AR="$(AR)" RANLIB="$(RANLIB)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" OBJCFLAGS="$(OBJCFLAGS)"
+
+# Adding strict flags for Mettle
+CFLAGS:=$(CFLAGS) -Wall -Werror
+ENV_METTLE:=$(ENV) ARFLAGS="cr" AR_FLAGS="cr" LDFLAGS="-L$(BUILD)/lib $(LDFLAGS)" CC="$(CC)" CPP="$(CPP)" AR="$(AR)" RANLIB="$(RANLIB)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" OBJCFLAGS="$(OBJCFLAGS)"
 
 LOGBUILD:=>>$(LOGFILE)
 ifeq "$(V)" "1"

--- a/make/Makefile.mettle
+++ b/make/Makefile.mettle
@@ -61,7 +61,7 @@ $(BUILD)/mettle/Makefile: $(TOOLS) $(ROOT)/mettle/configure \
 	@echo "Configuring mettle for $(TARGET)"
 	@mkdir -p $(BUILD)/mettle
 	@$(SETUP_BUILDENV) cd $(BUILD)/mettle; \
-		$(ENV) $(ROOT)/mettle/$(CONFIGURE) $(METTLE_OPTS) $(LOGBUILD)
+		$(ENV_METTLE) $(ROOT)/mettle/$(CONFIGURE) $(METTLE_OPTS) $(LOGBUILD)
 
 $(BUILD)/bin/mettle.built: $(BUILD)/mettle/Makefile
 	@echo "Building mettle for $(TARGET)"

--- a/make/Makefile.tools
+++ b/make/Makefile.tools
@@ -1,8 +1,19 @@
 ROOT=$(shell pwd)
 TOOLS=$(ROOT)/build/tools
 TOOLS_BIN=$(TOOLS)/bin
-TOOLS_ENV=ARFLAGS="cr" AR_FLAGS="cr" LDFLAGS="-L$(TOOLS)/lib -L$(TOOLS)/lib64" CFLAGS="-I$(TOOLS)/include -g -O2"
+TOOLS_CFLAGS=-I$(TOOLS)/include -g -O2 -std=gnu99
+TOOLS_ARFLAGS=cr
+TOOLS_LDFLAGS=-L$(TOOLS)/lib -L$(TOOLS)/lib64
+TOOLS_ENV=ARFLAGS="$(TOOLS_ARFLAGS)" AR_FLAGS="$(TOOLS_ARFLAGS)" LDFLAGS="$(TOOLS_LDFLAGS)" CFLAGS="$(TOOLS_CFLAGS)"
 TOOLS_CONFIGURE=$(TOOLS_ENV) ./configure --prefix=$(TOOLS) ac_cv_path_PKGCONFIG=$(ROOT)/deps/pkg-config --disable-shared
+
+# `-Wno-int-conversion` is required by flex, otherwise the build fails.
+# Note that this has been corrected upstream and upating the flex library
+# would be a good idea.
+FLEX_CFLAGS=$(TOOLS_CFLAGS) -Wno-int-conversion
+FLEX_ENV=ARFLAGS="$(TOOLS_ARFLAGS)" AR_FLAGS="$(TOOLS_ARFLAGS)" LDFLAGS="$(TOOLS_LDFLAGS)" CFLAGS="$(FLEX_CFLAGS)"
+FLEX_CONFIGURE=$(FLEX_ENV) ./configure --prefix=$(TOOLS) ac_cv_path_PKGCONFIG=$(ROOT)/deps/pkg-config --disable-shared
+
 BUILD_HOST=linux
 TOOLCHAIN_VERSION=6
 INSTALL=install
@@ -194,7 +205,7 @@ $(TOOLS)/flex/Makefile: $(ROOT)/deps/flex-2.5.39.tar.gz
         $(TAR) xf $(ROOT)/deps/flex-2.5.39.tar.gz; \
         mv flex-2.5.39 flex; \
         cd flex; \
-        $(TOOLS_CONFIGURE) $(LOGTOOLBUILD)
+        $(FLEX_CONFIGURE) $(LOGTOOLBUILD)
 
 $(TOOLS)/bin/flex: $(TOOLS)/flex/Makefile
 	@echo "Building flex"

--- a/mettle/configure.ac
+++ b/mettle/configure.ac
@@ -75,7 +75,8 @@ CHECK_LIBC_COMPAT
 CHECK_PROGNAME
 
 CFLAGS="$CFLAGS -Wall -Werror -std=gnu99 -fno-strict-aliasing -Wno-unused-variable -Wno-unused-function"
-CFLAGS="$CFLAGS -DBUILD_TUPLE=\\\"$TARGET\\\""
+AC_DEFINE_UNQUOTED([BUILD_TUPLE], ["${TARGET}]")
+AC_DEFINE([_FORTIFY_SOURCE], [0])
 
 AC_CONFIG_FILES([
 	Makefile


### PR DESCRIPTION
This fixes the build of Mettle on Mac OSX. Many of the issues are due to the dependencies. These library have some issues that prevent smooth compilation. I added some flags as a workaround, but updating the libraries to their latest versions would be a good idea. This might not fix everything, but should help. This is out-of-scope for this PR, but something to keep in mind.

Only Mettle is compiled with the restrictive `-Wall -Werror` flags.
