### PR TITLE
Bump version to 1.0.41

### DIFF
--- a/lib/metasploit_payloads/mettle/version.rb
+++ b/lib/metasploit_payloads/mettle/version.rb
@@ -1,7 +1,7 @@
 # -*- coding:binary -*-
 module MetasploitPayloads
   class Mettle
-    VERSION = '1.0.40'
+    VERSION = '1.0.41'
 
     def self.version
       VERSION


### PR DESCRIPTION
Manually bump the version to 1.0.41 - as the last CI job didn't succeed in the bump