### PR TITLE
Ensure argv[0] is not NULL

### DIFF
--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -270,7 +270,7 @@ int main(int argc, char * argv[])
 	/*
 	 * Check to see if we were injected by metasploit
 	 */
-	if (strcmp(argv[0], "m") == 0) {
+	if (argv[0] != NULL && strcmp(argv[0], "m") == 0) {
 		flags |= PAYLOAD_INJECTED;
 
 		/*


### PR DESCRIPTION
This fixes a bug discovered during the testing of https://github.com/rapid7/metasploit-framework/pull/19799

Specifically, with the introduction of the `in_memory_loader`, used to convert the ELF file to a shellcode (mainly to be able to prepend code on it) we deliver an elf file that execute the original mettle stageless payload by creating a file descriptor with `memfd_create` and executing it with `execve/execveat`. In this scenario, *some systems* (eg. Ubuntu 16.04 x86) receive an NULL inside the argv[0] making the payload segfault. This PR fixes this issue.