### PR TITLE
Fix flakey macho test failures

### DIFF
--- a/lib/metasploit_payloads/mettle.rb
+++ b/lib/metasploit_payloads/mettle.rb
@@ -97,12 +97,12 @@ module MetasploitPayloads
       end
       payload = [config_bytes.length].pack('N') + config_bytes
       padded = payload + "\x00" * (CONFIG_BLOCK_MAX - payload.length)
-      bin.sub(CONFIG_BLOCK_SIG + "\x00" * (CONFIG_BLOCK_MAX - CONFIG_BLOCK_SIG.length), padded)
+      bin.sub(CONFIG_BLOCK_SIG + "\x00" * (CONFIG_BLOCK_MAX - CONFIG_BLOCK_SIG.length)) { padded }
     end
 
     def add_args(bin, params)
       if params[8] != "\x00"
-        bin.sub(CMDLINE_SIG +  ' ' * (CMDLINE_MAX - CMDLINE_SIG.length), params)
+        bin.sub(CMDLINE_SIG +  ' ' * (CMDLINE_MAX - CMDLINE_SIG.length)) { params }
       else
         bin
       end

--- a/spec/metasploit_payloads/mettle/config_embedding_spec.rb
+++ b/spec/metasploit_payloads/mettle/config_embedding_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# Regression coverage for the binary-safe embedding of the mettle config block
+# and command-line argument slots.
+#
+# Both slots are filled with `String#sub`. When `sub` is given a *string*
+# replacement it interprets backslash sequences (\0-\9, \\, \k<>, \&, ...).
+# The config block is an (effectively random / XOR-encoded) binary blob, so it
+# routinely contains a 0x5c ("\") byte followed by a digit. With the string
+# form those sequences are expanded/dropped, which changes the length of the
+# produced binary, shifts the trailing LC_CODE_SIGNATURE SuperBlob and breaks
+# Mach-O signing downstream. The block form of `sub` does not interpret the
+# replacement, keeping the bytes verbatim.
+#
+# These examples are RED against `bin.sub(pattern, replacement)` and GREEN
+# against `bin.sub(pattern) { replacement }`.
+RSpec.describe MetasploitPayloads::Mettle do
+  subject { described_class.new('build-triple', {}) }
+
+  # A selection of payloads that all embed cleanly with the block form but that
+  # a string replacement would mangle (or, for the control cases, would not).
+  binary_payloads = [
+    { name: 'plain ascii bytes',                bytes: ('A'.b * 128) },
+    { name: 'a literal \0 backreference',       bytes: ('A'.b * 16) + "\x5c\x30".b + ('A'.b * 16) },
+    { name: 'a literal \1 backreference',       bytes: ('A'.b * 16) + "\x5c\x31".b + ('A'.b * 16) },
+    { name: 'a literal \& whole-match ref',     bytes: ('A'.b * 16) + "\x5c\x26".b + ('A'.b * 16) },
+    { name: 'a literal double backslash',       bytes: ('A'.b * 16) + "\x5c\x5c".b + ('A'.b * 16) },
+    { name: 'a trailing null byte',             bytes: ('A'.b * 32) + "\x00".b },
+    { name: 'every possible byte value',        bytes: (0..255).to_a.pack('C*') }
+  ]
+
+  describe '#add_config_block' do
+    let(:sig) { described_class::CONFIG_BLOCK_SIG }
+    let(:max) { described_class::CONFIG_BLOCK_MAX }
+    let(:prefix) { 'MACHO-HEADER'.b }
+    let(:suffix) { 'TRAILING-SIGNATURE'.b }
+    let(:reserved_slot) { sig.b + ("\x00".b * (max - sig.length)) }
+    let(:binary) { prefix + reserved_slot + suffix }
+
+    binary_payloads.each do |test|
+      context "when the config block contains #{test[:name]}" do
+        let(:config_bytes) { test[:bytes] }
+        let(:result) { subject.send(:add_config_block, binary.dup, config_bytes) }
+
+        it 'preserves the overall binary size' do
+          expect(result.length).to eq(binary.length)
+        end
+
+        it 'writes the 4-byte big-endian length prefix' do
+          expect(result[prefix.length, 4]).to eq([config_bytes.length].pack('N'))
+        end
+
+        it 'writes the config bytes verbatim into the reserved slot' do
+          expect(result[prefix.length + 4, config_bytes.length]).to eq(config_bytes)
+        end
+
+        it 'leaves the surrounding bytes untouched' do
+          expect(result).to start_with(prefix)
+          expect(result).to end_with(suffix)
+        end
+      end
+    end
+
+    context 'when the config block is larger than the reserved slot' do
+      it 'raises an error' do
+        expect do
+          subject.send(:add_config_block, binary.dup, 'A'.b * (max - 3))
+        end.to raise_error(described_class::Error, 'mettle config block too large')
+      end
+    end
+  end
+
+  describe '#add_args' do
+    let(:sig) { described_class::CMDLINE_SIG }
+    let(:max) { described_class::CMDLINE_MAX }
+    let(:prefix) { 'MACHO-HEADER'.b }
+    let(:suffix) { 'TRAILING-SIGNATURE'.b }
+    let(:reserved_slot) { sig.b + (' '.b * (max - sig.length)) }
+    let(:binary) { prefix + reserved_slot + suffix }
+
+    cmdline_max = MetasploitPayloads::Mettle::CMDLINE_MAX
+
+    binary_payloads.each do |test|
+      # add_args only rewrites the slot when params[8] is not a null byte, so
+      # build a params buffer of the required length whose 9th byte is set.
+      params = ('mettle '.b + test[:bytes])[0, cmdline_max]
+      params += "\x00".b * (cmdline_max - params.length)
+
+      next if params[8] == "\x00".b
+
+      context "when the argument buffer contains #{test[:name]}" do
+        let(:result) { subject.send(:add_args, binary.dup, params) }
+
+        it 'preserves the overall binary size' do
+          expect(result.length).to eq(binary.length)
+        end
+
+        it 'writes the params verbatim into the reserved slot' do
+          expect(result[prefix.length, max]).to eq(params)
+        end
+
+        it 'leaves the surrounding bytes untouched' do
+          expect(result).to start_with(prefix)
+          expect(result).to end_with(suffix)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The CI tests showed a ~6% chance of OSX payloads breaking:

```
bundle exec rspec ./spec/modules/payloads_spec.rb

Overriding user environment variable 'OPENSSL_CONF' to enable legacy functions.
Run options:
  include {:focus=>true}
  exclude {:acceptance=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 63326
Acceptance::DatastoreFormatting .......
modules/payloads ..............................................................................................................................................................................................................................................................................................................................................................................F.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

  1) modules/payloads osx/aarch64/meterpreter_reverse_https it should behave like payload cached size is consistent osx/aarch64/meterpreter_reverse_https can be instantiated and generated
     Failure/Error: raise "Invalid kSecCodeMagicEmbeddedSignature magic for macho" if s_magic != 0xfade0cc0

     RuntimeError:
       Invalid kSecCodeMagicEmbeddedSignature magic for macho
     Shared Example Group: "payload cached size is consistent" called from ./spec/modules/payloads_spec.rb:2536
     # ./lib/msf/core/payload/macho.rb:66:in `sign'
     # ./modules/payloads/singles/osx/aarch64/meterpreter_reverse_https.rb:41:in `generate'
     # ./lib/msf/core/payload.rb:309:in `generate_complete'
     # ./lib/msf/core/encoded_payload.rb:118:in `generate_raw'
     # ./lib/msf/core/encoded_payload.rb:74:in `generate'
     # ./lib/msf/core/encoded_payload.rb:24:in `create'
     # ./lib/msf/base/simple/payload.rb:52:in `generate_simple'
     # ./lib/msf/base/simple/payload.rb:139:in `generate_simple'
     # ./lib/msf/util/payload_cached_size.rb:174:in `compute_cached_size'
```

The TL:DR being:

Before: mettle embedded the config block with `String#sub(pattern, replacement)`, and Ruby interprets backslash sequences (`\0`, `\1`, etc.) in the string replacement — so random config bytes containing `\`+char got expanded or dropped, changing the binary's size and shifting the Mach-O code signature out of place, which broke signing.

The fix uses the block form `sub(pattern) { replacement }`, which inserts the bytes verbatim without interpreting backreferences, so the binary keeps its exact size and the signature stays valid.